### PR TITLE
Fix crash on paths with spaces

### DIFF
--- a/src/main/java/de/zannagh/armorhider/configuration/ConfigurationItemFactoryRegistry.java
+++ b/src/main/java/de/zannagh/armorhider/configuration/ConfigurationItemFactoryRegistry.java
@@ -13,6 +13,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Centralized registry for ConfigurationItemBase factory methods.
@@ -129,7 +131,8 @@ public class ConfigurationItemFactoryRegistry {
                         File directory = new File(resource.toURI());
                         classes.addAll(findClassesInDirectory(directory, packageName));
                     } else if (resource.getProtocol().equals("jar")) {
-                        String jarPath = resource.getPath().substring(5, resource.getPath().indexOf("!"));
+                        String rawPath = resource.getPath().substring(5, resource.getPath().indexOf("!"));
+                        String jarPath = URLDecoder.decode(rawPath, StandardCharsets.UTF_8);
                         classes.addAll(findClassesInJar(jarPath, path));
                     }
                 }


### PR DESCRIPTION
The game would crash with java.nio.file.NoSuchFileException if the installation path contained spaces (e.g., D:\Program Files\PCLCE\\.minecraft). This happened because ConfigurationItemFactoryRegistry was using the raw URL path (where spaces are encoded as %20) to access the JAR file.