### PR TITLE
fix: network protocol issue serverwide settings, closes #32 (#33)

### DIFF
--- a/src/client/java/de/zannagh/armorhider/config/ClientConfigManager.java
+++ b/src/client/java/de/zannagh/armorhider/config/ClientConfigManager.java
@@ -81,6 +81,11 @@ public class ClientConfigManager implements ConfigurationProvider<PlayerConfig> 
     
     public void setServerConfig(ServerConfiguration serverConfig) {
         ArmorHider.LOGGER.info("Setting server config...");
+        if (serverConfig.serverWideSettings == null) {
+            ArmorHider.LOGGER.warn("Received ServerConfiguration with null serverWideSettings, initializing with defaults");
+            serverConfig.serverWideSettings = new ServerWideSettings();
+        }
+
         serverConfiguration = serverConfig;
     }
 

--- a/src/main/java/de/zannagh/armorhider/ArmorHider.java
+++ b/src/main/java/de/zannagh/armorhider/ArmorHider.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import de.zannagh.armorhider.common.EnrichedLogger;
 import de.zannagh.armorhider.configuration.ConfigurationItemSerializer;
 import de.zannagh.armorhider.configuration.ConfigurationSourceSerializer;
+import de.zannagh.armorhider.configuration.ServerConfigurationDeserializer;
 import de.zannagh.armorhider.net.CommsManager;
 import de.zannagh.armorhider.net.PayloadRegistrar;
 import de.zannagh.armorhider.net.ServerRuntime;
@@ -17,6 +18,7 @@ import org.slf4j.LoggerFactory;
 public class ArmorHider implements ModInitializer {
     public static final Gson GSON = new GsonBuilder()
             .setPrettyPrinting()
+            .registerTypeAdapterFactory(new ServerConfigurationDeserializer())
             .registerTypeAdapterFactory(new ConfigurationSourceSerializer())
             .registerTypeAdapterFactory(new ConfigurationItemSerializer())
             .create();

--- a/src/main/java/de/zannagh/armorhider/configuration/ServerConfigurationDeserializer.java
+++ b/src/main/java/de/zannagh/armorhider/configuration/ServerConfigurationDeserializer.java
@@ -1,0 +1,66 @@
+package de.zannagh.armorhider.configuration;
+
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import de.zannagh.armorhider.ArmorHider;
+import de.zannagh.armorhider.resources.ServerConfiguration;
+import de.zannagh.armorhider.resources.ServerWideSettings;
+
+import java.io.IOException;
+
+/**
+ * Custom Gson TypeAdapter for ServerConfiguration that handles migration from older config formats.
+ * <p>
+ * This ensures that when ServerConfiguration is received over the network from servers
+ * running older versions (e.g., 0.4.x with v3 format where enableCombatDetection was a top-level field),
+ * the configuration is properly migrated to the current format.
+ */
+public class ServerConfigurationDeserializer implements TypeAdapterFactory {
+
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+        if (!ServerConfiguration.class.equals(typeToken.getRawType())) {
+            return null;
+        }
+
+        TypeAdapter<T> defaultAdapter = gson.getDelegateAdapter(this, typeToken);
+
+        return new TypeAdapter<>() {
+            @Override
+            public void write(JsonWriter out, T value) throws IOException {
+                defaultAdapter.write(out, value);
+            }
+
+            @Override
+            public T read(JsonReader in) {
+                JsonElement jsonElement = JsonParser.parseReader(in);
+
+                if (!jsonElement.isJsonObject()) {
+                    throw new JsonParseException("Expected JsonObject for ServerConfiguration");
+                }
+
+                JsonObject obj = jsonElement.getAsJsonObject();
+
+                ServerConfiguration config = (ServerConfiguration) defaultAdapter.fromJsonTree(jsonElement);
+
+                // Handle v3 format migration: enableCombatDetection was a top-level Boolean field
+                if (obj.has("enableCombatDetection") && !obj.has("serverWideSettings")) {
+                    Boolean legacyCombatDetection = obj.get("enableCombatDetection").getAsBoolean();
+                    config.serverWideSettings = new ServerWideSettings(legacyCombatDetection);
+                    ArmorHider.LOGGER.info("Migrated server config from v3 to v4 format via network (enableCombatDetection -> serverWideSettings).");
+                    config.setHasChangedFromSerializedContent();
+                } else if (config.serverWideSettings == null) {
+                    // Fallback: if somehow serverWideSettings is still null, initialize with defaults
+                    config.serverWideSettings = new ServerWideSettings();
+                    ArmorHider.LOGGER.warn("ServerWideSettings was null after network deserialization, initialized with defaults.");
+                }
+
+                @SuppressWarnings("unchecked")
+                T result = (T) config;
+                return result;
+            }
+        };
+    }
+}

--- a/src/main/java/de/zannagh/armorhider/resources/ServerConfiguration.java
+++ b/src/main/java/de/zannagh/armorhider/resources/ServerConfiguration.java
@@ -43,8 +43,9 @@ public class ServerConfiguration implements ConfigurationSource<ServerConfigurat
     public ServerWideSettings serverWideSettings;
 
     public ServerConfiguration() {
-        // Don't initialize serverWideSettings here - let deserialization handle it
-        // This allows migration logic to detect v3 format (where serverWideSettings is missing)
+        // Always initialize serverWideSettings with defaults to prevent null pointer exceptions
+        // Migration logic will detect v3 format by checking for old field presence
+        this.serverWideSettings = new ServerWideSettings();
     }
 
     private ServerConfiguration(Map<UUID, PlayerConfig> playerConfigs, ServerWideSettings serverWideSettings) {
@@ -95,14 +96,16 @@ public class ServerConfiguration implements ConfigurationSource<ServerConfigurat
                 configuration = ArmorHider.GSON.fromJson(element, ServerConfiguration.class);
 
                 // Check if we need to migrate from v3 format (enableCombatDetection boolean) to v4 (serverWideSettings object)
-                if (configuration.serverWideSettings == null && obj.has("enableCombatDetection")) {
+                // Detect v3 by presence of old field and absence of new field in JSON
+                if (obj.has("enableCombatDetection") && !obj.has("serverWideSettings")) {
                     Boolean legacyCombatDetection = obj.get("enableCombatDetection").getAsBoolean();
                     configuration.serverWideSettings = new ServerWideSettings(legacyCombatDetection);
                     ArmorHider.LOGGER.info("Migrated server config from v3 to v4 format (enableCombatDetection -> serverWideSettings).");
                     configuration.setHasChangedFromSerializedContent();
                 } else if (configuration.serverWideSettings == null) {
-                    // No serverWideSettings and no legacy field - use defaults
+                    // Safety fallback: if somehow serverWideSettings is still null, initialize with defaults
                     configuration.serverWideSettings = new ServerWideSettings();
+                    ArmorHider.LOGGER.warn("ServerWideSettings was null after deserialization, initialized with defaults.");
                 } else {
                     ArmorHider.LOGGER.info("Loaded server config (v4 format).");
                 }


### PR DESCRIPTION
* fix: null check server wide settings and handle migration from older versions with respect to these settings being null
* fix: being extra sure, use custom deserializer and add additional null checks on client side
* fix: skin options to not fail on missing server configuration