### PR TITLE
fix: fix player name being null on local player render and closes #40

### DIFF
--- a/src/client/java/de/zannagh/armorhider/client/ArmorHiderClient.java
+++ b/src/client/java/de/zannagh/armorhider/client/ArmorHiderClient.java
@@ -10,7 +10,6 @@ import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.PlayerListEntry;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import oshi.util.tuples.Pair;
 
 public class ArmorHiderClient implements ClientModInitializer {
@@ -23,8 +22,11 @@ public class ArmorHiderClient implements ClientModInitializer {
                 || (MinecraftClient.getInstance().getNetworkHandler() != null && MinecraftClient.getInstance().getNetworkHandler().getServerInfo() != null);
     }
     
-    public static @Nullable String getCurrentPlayerName() { 
-        return MinecraftClient.getInstance().player instanceof ClientPlayerEntity clientPlayer && clientPlayer.getDisplayName() instanceof net.minecraft.text.Text displayText ? displayText.getString() : null;
+    public static String getCurrentPlayerName() { 
+        return MinecraftClient.getInstance().player instanceof ClientPlayerEntity clientPlayer 
+                && clientPlayer.getDisplayName() instanceof net.minecraft.text.Text displayText 
+                ? displayText.getString() 
+                : ClientConfigManager.DEFAULT_PLAYER_NAME;
     }
     
     @Contract("_ -> new")

--- a/src/client/java/de/zannagh/armorhider/config/ClientConfigManager.java
+++ b/src/client/java/de/zannagh/armorhider/config/ClientConfigManager.java
@@ -7,15 +7,19 @@ import de.zannagh.armorhider.resources.PlayerConfig;
 import de.zannagh.armorhider.resources.ServerConfiguration;
 import de.zannagh.armorhider.resources.ServerWideSettings;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
 public class ClientConfigManager implements ConfigurationProvider<PlayerConfig> {
     
+    public static final String DEFAULT_PLAYER_NAME = "dummy";
+    
+    public static final UUID DEFAULT_PLAYER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+    
     private final ConfigurationProvider<PlayerConfig> playerConfigProvider;
 
-    private PlayerConfig CURRENT = PlayerConfig.defaults(UUID.randomUUID(), "dummy");
+    private PlayerConfig CURRENT = PlayerConfig.defaults(DEFAULT_PLAYER_ID, DEFAULT_PLAYER_NAME);
     
     private ServerConfiguration serverConfiguration = new ServerConfiguration();
     
@@ -95,8 +99,8 @@ public class ClientConfigManager implements ConfigurationProvider<PlayerConfig> 
     
     public void setValue(PlayerConfig cfg) { CURRENT = cfg; saveCurrent(); }
 
-    public PlayerConfig getConfigForPlayer(@Nullable String playerName) {
-        if (playerName != null && playerName.equals(ArmorHiderClient.getCurrentPlayerName())) {
+    public PlayerConfig getConfigForPlayer(@NotNull String playerName) {
+        if (playerName.equals(ArmorHiderClient.getCurrentPlayerName())) {
             return CURRENT;
         }
         
@@ -107,7 +111,7 @@ public class ClientConfigManager implements ConfigurationProvider<PlayerConfig> 
         
         var isRemotePlayer = ArmorHiderClient.isPlayerRemotePlayer(playerName);
         
-        UUID playerId = UUID.randomUUID();
+        UUID playerId = DEFAULT_PLAYER_ID;
         if (isRemotePlayer.getA()) {
             playerId = isRemotePlayer.getB().getProfile().id();
             config = serverConfiguration.getPlayerConfigOrDefault(isRemotePlayer.getB().getProfile().id());

--- a/src/client/java/de/zannagh/armorhider/mixin/client/bodyKneesAndToes/EquipmentRenderMixin.java
+++ b/src/client/java/de/zannagh/armorhider/mixin/client/bodyKneesAndToes/EquipmentRenderMixin.java
@@ -24,6 +24,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.equipment.EquipmentAsset;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.Identifier;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -64,6 +65,20 @@ public class EquipmentRenderMixin {
             ci.cancel();
         }
     }
+    
+    @WrapOperation(
+            method = "render(Lnet/minecraft/client/render/entity/equipment/EquipmentModel$LayerType;Lnet/minecraft/registry/RegistryKey;Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/command/OrderedRenderCommandQueue;II)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/render/entity/equipment/EquipmentRenderer;render(Lnet/minecraft/client/render/entity/equipment/EquipmentModel$LayerType;Lnet/minecraft/registry/RegistryKey;Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/command/OrderedRenderCommandQueue;ILnet/minecraft/util/Identifier;II)V"
+            )
+    )
+    private static <S> void wrap(EquipmentRenderer instance, EquipmentModel.LayerType layerType, RegistryKey<EquipmentAsset> assetKey, Model<? super S> model, S state, ItemStack stack, MatrixStack matrices, OrderedRenderCommandQueue queue, int light, @Nullable Identifier textureId, int outlineColor, int initialOrder, Operation<Void> original){
+        if (!ArmorRenderPipeline.shouldHideEquipment()) {
+            original.call(instance, layerType, assetKey, model, state, stack, matrices, queue, light, textureId, outlineColor, initialOrder);
+        }
+    }
+    
     @ModifyExpressionValue(
             method = "render(Lnet/minecraft/client/render/entity/equipment/EquipmentModel$LayerType;Lnet/minecraft/registry/RegistryKey;Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/command/OrderedRenderCommandQueue;ILnet/minecraft/util/Identifier;II)V",
             at = @At(

--- a/src/client/java/de/zannagh/armorhider/rendering/ArmorRenderPipeline.java
+++ b/src/client/java/de/zannagh/armorhider/rendering/ArmorRenderPipeline.java
@@ -21,7 +21,7 @@ public class ArmorRenderPipeline {
 
     /// See ElytraRenderPriority. Skull should usually render ahead of Elytra, in case the Elytra is visually infront of the skull.
     public static final int SkullRenderPriority = 99;
-
+    
     /// Captures context for the render pipeline, used within other methods of the class.
     /// ItemStack can be null, slot can be null.
     public static void setupContext(ItemStack itemStack, EquipmentSlot slot, LivingEntityRenderState entityRenderState) {
@@ -66,7 +66,8 @@ public class ArmorRenderPipeline {
     }
 
     private static ArmorModificationInfo tryResolveConfigFromPlayerEntityState(EquipmentSlot slot, PlayerEntityRenderState state){
-        return new ArmorModificationInfo(slot, ArmorHiderClient.CLIENT_CONFIG_MANAGER.getConfigForPlayer(state.displayName == null ? null : state.displayName.getString()));
+        boolean isLocalPlayerEntityRenderState = state.displayName == null;
+        return new ArmorModificationInfo(slot, ArmorHiderClient.CLIENT_CONFIG_MANAGER.getConfigForPlayer(isLocalPlayerEntityRenderState ? ArmorHiderClient.getCurrentPlayerName() : state.displayName.getString()));
     }
 
     private static void setCurrentSlot(EquipmentSlot slot) {

--- a/src/main/java/de/zannagh/armorhider/resources/ArmorModificationInfo.java
+++ b/src/main/java/de/zannagh/armorhider/resources/ArmorModificationInfo.java
@@ -20,7 +20,7 @@ public record ArmorModificationInfo(EquipmentSlot equipmentSlot, @NotNull Player
 
     public boolean shouldHide() {
         double transparency = getTransparency();
-        return transparency < ArmorOpacity.TRANSPARENCY_STEP + ArmorOpacity.TRANSPARENCY_STEP / 2;
+        return transparency < ArmorOpacity.TRANSPARENCY_STEP;
     }
 
     public boolean shouldModify() {


### PR DESCRIPTION
* add additional WrapOperation to cancel out rendering on items that should be hidden
* catch the local player's displayname being null when acquired through the EntityRenderState