### PR TITLE
feat: save server config stores within world context, closes #66

### DIFF
--- a/src/main/java/de/zannagh/armorhider/ArmorHider.java
+++ b/src/main/java/de/zannagh/armorhider/ArmorHider.java
@@ -14,6 +14,12 @@ import de.zannagh.armorhider.netPackets.CompressedJsonCodec;
 import net.fabricmc.api.ModInitializer;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import net.minecraft.world.level.storage.LevelResource;
+
 public class ArmorHider implements ModInitializer {
     public static final Gson GSON = new GsonBuilder()
             .setPrettyPrinting()
@@ -24,24 +30,51 @@ public class ArmorHider implements ModInitializer {
     public static final String MOD_ID = "armor-hider";
     public static final EnrichedLogger LOGGER = new EnrichedLogger(LoggerFactory.getLogger(MOD_ID));
 
+    private static volatile ServerRuntime runtime = null;
+
+    public static ServerRuntime getRuntime() {
+        return runtime;
+    }
+
     @Override
     public void onInitialize() {
         LOGGER.info("Initializing...");
 
         // Register server lifecycle events
         ServerLifecycleEvents.registerStarting(server -> {
-            ServerRuntime.init(server);
+            Path worldConfigPath = getWorldConfigPath(server);
+            migrateGlobalConfigIfNeeded(worldConfigPath);
+            runtime = new ServerRuntime(server, worldConfigPath);
             LOGGER.info("Server config store opened");
         });
         ServerLifecycleEvents.registerStopping(server -> {
-            if (ServerRuntime.store != null) {
-                ServerRuntime.store.saveCurrent();
+            if (runtime != null) {
+                runtime.getStore().saveCurrent();
             }
+            runtime = null;
         });
 
         CompressedJsonCodec.setGson(GSON);
         PayloadRegistry.init();
         CommsManager.initServer();
         LOGGER.info("Initialized!");
+    }
+
+    private static Path getWorldConfigPath(net.minecraft.server.MinecraftServer server) {
+        Path worldDir = server.getWorldPath(LevelResource.ROOT);
+        return worldDir.resolve("armor-hider.json");
+    }
+
+    private static void migrateGlobalConfigIfNeeded(Path worldConfigPath) {
+        Path globalConfig = new File("config", "armor-hider-server.json").toPath();
+        if (Files.exists(globalConfig) && !Files.exists(worldConfigPath)) {
+            try {
+                Files.createDirectories(worldConfigPath.getParent());
+                Files.copy(globalConfig, worldConfigPath);
+                LOGGER.info("Migrated global config to world: {}", worldConfigPath);
+            } catch (IOException e) {
+                LOGGER.error("Failed to migrate config", e);
+            }
+        }
     }
 }

--- a/src/main/java/de/zannagh/armorhider/net/ServerRuntime.java
+++ b/src/main/java/de/zannagh/armorhider/net/ServerRuntime.java
@@ -4,18 +4,28 @@ import de.zannagh.armorhider.resources.PlayerConfig;
 import de.zannagh.armorhider.resources.ServerConfigStore;
 import net.minecraft.server.MinecraftServer;
 
+import java.nio.file.Path;
 import java.util.UUID;
 
 public final class ServerRuntime {
-    public static ServerConfigStore store;
-    public static MinecraftServer server;
+    private final ServerConfigStore store;
+    private final MinecraftServer server;
 
-    public static void init(MinecraftServer s) {
-        server = s;
-        store = new ServerConfigStore();
+    public ServerRuntime(MinecraftServer server, Path configPath) {
+        this.server = server;
+        this.store = new ServerConfigStore(configPath);
     }
 
-    public static void put(UUID id, PlayerConfig c) {
+    public ServerConfigStore getStore() {
+        return store;
+    }
+
+    public MinecraftServer getServer() {
+        return server;
+    }
+
+    public void put(UUID id, PlayerConfig c) {
         store.put(id, c);
+        store.saveCurrent();
     }
 }


### PR DESCRIPTION
* server store path containing the player configs should now be stored within the world context (next to level.dat as armor-hider.json
* migration from old versions to carry in any pre-existing player configurations and prevent backwards compatibility problems