### PR TITLE
fix: ui options disabled when not on server for specific settings, closes #72

### DIFF
--- a/src/common/java/de/zannagh/armorhider/common/constants/UiConstants.java
+++ b/src/common/java/de/zannagh/armorhider/common/constants/UiConstants.java
@@ -1,0 +1,6 @@
+package de.zannagh.armorhider.common.constants;
+
+public final class UiConstants {
+    public static final int DEFAULT_BUTTON_WIDTH = 150;
+    public static final int BIG_BUTTON_WIDTH = 310;
+}


### PR DESCRIPTION
* disables the server side settings in the UI when not on server
* for 1.20.x there is no easy way to incorporate this (that wouldn't require rewriting that screen) since AbstractWidgets cannot be added to the OptionsList directly