### PR TITLE
chore: add codec/payload registration guard, fixes #74

### DIFF
--- a/src/main/java/de/zannagh/armorhider/net/PayloadInjectionGuard.java
+++ b/src/main/java/de/zannagh/armorhider/net/PayloadInjectionGuard.java
@@ -1,0 +1,21 @@
+//? if >= 1.20.5 {
+package de.zannagh.armorhider.net;
+
+/**
+ * Guard against re-entrancy when other mods (like Carpet) also mixin to the same codec method.
+ * This prevents infinite recursion when their mixins call back into the codec method.
+ */
+public final class PayloadInjectionGuard {
+    private static final ThreadLocal<Boolean> IS_INJECTING = ThreadLocal.withInitial(() -> false);
+
+    private PayloadInjectionGuard() {}
+
+    public static boolean isInjecting() {
+        return IS_INJECTING.get();
+    }
+
+    public static void setInjecting(boolean value) {
+        IS_INJECTING.set(value);
+    }
+}
+//?}


### PR DESCRIPTION
* prevents re-entrancy and infinite recursion within the custom payload injection when other mods are using the same path to inject their payload