### PR TITLE
fix: add render cancellation when skull opacity is at zero, fix skull mixin, fixes #87, fixes #88

### DIFF
--- a/src/client/java/de/zannagh/armorhider/mixin/client/head/CustomHeadLayerMixin.java
+++ b/src/client/java/de/zannagh/armorhider/mixin/client/head/CustomHeadLayerMixin.java
@@ -33,10 +33,15 @@ public abstract class CustomHeadLayerMixin {
     @Inject(
             method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;FF)V",
             at = @At("HEAD"),
-            order = MixinConstants.HIGH_PRIO
+            order = MixinConstants.HIGH_PRIO,
+            cancellable = true
     )
     private <S extends LivingEntityRenderState> void interceptHeadLayerRender(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int i, S livingEntityRenderState, float f, float g, CallbackInfo ci) {
         setupContextBasedOnWornHeadType(livingEntityRenderState);
+        if (ArmorRenderPipeline.shouldHideEquipment()) {
+            ci.cancel();
+            ArmorRenderPipeline.clearContext();
+        }
     }
 
     @Inject(
@@ -103,10 +108,15 @@ public abstract class CustomHeadLayerMixin {
     @Inject(
             method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;FF)V",
             at = @At("HEAD"),
-            order = MixinConstants.HIGH_PRIO
+            order = MixinConstants.HIGH_PRIO,
+            cancellable = true
     )
     private <S extends LivingEntityRenderState> void interceptHeadLayerRender(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, S livingEntityRenderState, float f, float g, CallbackInfo ci) {
         setupContextBasedOnWornHeadType(livingEntityRenderState);
+        if (ArmorRenderPipeline.shouldHideEquipment()) {
+            ci.cancel();
+            ArmorRenderPipeline.clearContext();
+        }
     }
 
     @Inject(
@@ -156,7 +166,8 @@ public abstract class CustomHeadLayerMixin<T extends LivingEntity> {
     @Inject(
             method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V",
             at = @At("HEAD"),
-            order = MixinConstants.HIGH_PRIO
+            order = MixinConstants.HIGH_PRIO,
+            cancellable = true
     )
     private void interceptHeadLayerRender(PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, T entity, float limbSwing, float limbSwingAmount, float partialTick, float ageInTicks, float netHeadYaw, float headPitch, CallbackInfo ci) {
         if (ArmorRenderPipeline.entityIsNotPlayer(entity)) {
@@ -164,6 +175,10 @@ public abstract class CustomHeadLayerMixin<T extends LivingEntity> {
         }
         
         ArmorRenderPipeline.setupContext(entity.getItemBySlot(EquipmentSlot.HEAD), EquipmentSlot.HEAD, entity);
+        if (ArmorRenderPipeline.shouldHideEquipment()) {
+            ci.cancel();
+            ArmorRenderPipeline.clearContext();
+        }
     }
 
     @Inject(

--- a/src/client/java/de/zannagh/armorhider/mixin/client/head/SkullBlockRenderMixin.java
+++ b/src/client/java/de/zannagh/armorhider/mixin/client/head/SkullBlockRenderMixin.java
@@ -49,6 +49,9 @@ public abstract class SkullBlockRenderMixin {
                 original.call(instance, model, o, poseStack, renderType, i, j, k, crumblingOverlay);
                 return;
             }
+            if (ArmorRenderPipeline.shouldHideEquipment()) {
+                return;
+            }
             var modifiedColor = ArmorRenderPipeline.applyTransparencyFromWhite(255);
             instance.order(ArmorRenderPipeline.SkullRenderPriority).submitModel(model, o, poseStack, renderType, i, j, modifiedColor, null, k, crumblingOverlay);
         } finally {
@@ -107,7 +110,6 @@ import net.minecraft.client.model.SkullModelBase;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.SkullBlockRenderer;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.block.SkullBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -122,6 +124,9 @@ public abstract class SkullBlockRenderMixin {
     )
     private static void modifyTransparency(SkullModelBase instance, PoseStack poseStack, VertexConsumer vertexConsumer, int light, int overlay, Operation<Void> original) {
         if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+            if (ArmorRenderPipeline.shouldHideEquipment()) {
+                return;
+            }
             int modifiedColor = ArmorRenderPipeline.applyTransparencyFromWhite(-1);
             instance.renderToBuffer(poseStack, vertexConsumer, light, overlay, modifiedColor);
         } else {
@@ -133,11 +138,11 @@ public abstract class SkullBlockRenderMixin {
             method = "getRenderType",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/client/renderer/blockentity/SkullBlockRenderer;getSkullRenderType(Lnet/minecraft/world/level/block/SkullBlock$Type;Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/renderer/RenderType;"
+                    target = "Lnet/minecraft/client/renderer/RenderType;entityCutoutNoCullZOffset(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/renderer/RenderType;"
             )
     )
-    private static RenderType modifySkullTransparency(SkullBlock.Type type, ResourceLocation resourceLocation, Operation<RenderType> original) {
-        return ArmorRenderPipeline.getSkullRenderLayer(resourceLocation, original.call(type, resourceLocation));
+    private static RenderType modifySkullTransparency(ResourceLocation resourceLocation, Operation<RenderType> original) {
+        return ArmorRenderPipeline.getSkullRenderLayer(resourceLocation, original.call(resourceLocation));
     }
 }
 *///?}
@@ -168,6 +173,9 @@ public abstract class SkullBlockRenderMixin {
     )
     private static void modifyTransparency(SkullModelBase instance, PoseStack poseStack, VertexConsumer vertexConsumer, int light, int overlay, Operation<Void> original) {
         if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+            if (ArmorRenderPipeline.shouldHideEquipment()) {
+                return;
+            }
             int modifiedColor = ArmorRenderPipeline.applyTransparencyFromWhite(-1);
             instance.renderToBuffer(poseStack, vertexConsumer, light, overlay, modifiedColor);
         } else {
@@ -234,6 +242,9 @@ public abstract class SkullBlockRenderMixin {
         if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
             if (!ArmorRenderPipeline.getCurrentModification().playerConfig().opacityAffectingHatOrSkull.getValue()) {
                 original.call(instance, poseStack, vertexConsumer, light, overlay, red, green, blue, alpha);
+                return;
+            }
+            if (ArmorRenderPipeline.shouldHideEquipment()) {
                 return;
             }
 


### PR DESCRIPTION
## Description
See #87 and #88 for the targeted issues.

## Motivation and Context
A similar issue has already been present with armor items, see #40 

## How has this been tested, if applicable?
All supported game versions start and run, the visual artifact when standing in front of a water body is no longer present at 0% opacity on helmet with affect skulls ON and a skeleton skull equipped.