### PR TITLE
fix: prevent premature class loading causing ClassCastException

### DIFF
--- a/common/src/main/java/de/zannagh/armorhider/util/MixinUtil.java
+++ b/common/src/main/java/de/zannagh/armorhider/util/MixinUtil.java
@@ -11,11 +11,11 @@ public final class MixinUtil {
         var list = new ArrayList<String>();
         for (String mixin : expectedClasses) {
             String mixinClassName = packageName + "." + mixin;
-            try {
-                Class.forName(mixinClassName, false, MixinUtil.class.getClassLoader());
+            String resourcePath = mixinClassName.replace('.', '/') + ".class";
+            if (MixinUtil.class.getClassLoader().getResource(resourcePath) != null) {
                 ArmorHider.LOGGER.debug("Applying present mixin: '{}'.", mixinClassName);
                 list.add(mixin);
-            } catch (ClassNotFoundException ignored) {
+            } else {
                 ArmorHider.LOGGER.debug("Skipping missing mixin: '{}'.", mixinClassName);
             }
         }


### PR DESCRIPTION
## Description
Replaced the use of `Class.forName()` with `ClassLoader.getResource()` in `MixinUtil.getMixinClassesWherePresent()`. This safely checks for the existence of mixin target classes without triggering JVM class loading.

## Motivation and Context
Using `Class.forName()` during the `IMixinConfigPlugin` phase loaded Minecraft screen classes (like `Screen` and `SkinCustomizationScreen`) too early. This prevented the Fabric API from successfully injecting the `ScreenExtensions` interface, which resulted in a `ClassCastException` upon client startup.

Here is the crash report encountered on `fabric-1.21.11`:

<details>
<summary><b>Crash Log</b></summary>

```text
---- Minecraft Crash Report ----
// Don't be sad, have a hug! <3

Time: 2026-02-25 12:20:44
Description: Ticking screen

java.lang.ClassCastException: class net.minecraft.class_424 cannot be cast to class net.fabricmc.fabric.impl.client.screen.ScreenExtensions (net.minecraft.class_424 and net.fabricmc.fabric.impl.client.screen.ScreenExtensions are in unnamed module of loader 'knot' @7a9273a8)
	at knot//net.fabricmc.fabric.impl.client.screen.ScreenExtensions.getExtensions(ScreenExtensions.java:31)
	at knot//net.fabricmc.fabric.api.client.screen.v1.ScreenEvents.beforeTick(ScreenEvents.java:159)
	at knot//net.minecraft.class_310.handler$cnk000$fabric-screen-api-v1$beforeScreenTick(class_310.java:13179)
	at knot//net.minecraft.class_310.method_1574(class_310.java:1908)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1354)
	at knot//net.minecraft.class_310.method_1514(class_310.java:966)
	at knot//net.minecraft.client.main.Main.main(Main.java:250)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
```
</details>

## How has this been tested, if applicable?
Compiled the `fabric-1.21.11` artifact using `./gradlew :fabric:build`. Launched the Fabric client to verify that the game boots successfully without the `ClassCastException` and that the Armor Hider options menu renders and operates correctly.

## Screenshots (if appropriate):
(N/A)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.