### PR TITLE
fix: main hand getting hidden due to context leak, fixes #101

### DIFF
--- a/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/ItemInHandLayerMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/ItemInHandLayerMixin.java
@@ -67,7 +67,7 @@ public class ItemInHandLayerMixin {
         //? if < 1.21.4
         //ArmorRenderPipeline.setupContext(itemState, EquipmentSlot.OFFHAND, humanoidState);
 
-        if (ArmorRenderPipeline.hasActiveContext()
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND)
                 && ArmorRenderPipeline.shouldModifyEquipment()
                 && ArmorRenderPipeline.shouldHideEquipment()) {
             ArmorRenderPipeline.clearContext();

--- a/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/ItemRenderStateMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/ItemRenderStateMixin.java
@@ -7,6 +7,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import de.zannagh.armorhider.rendering.ArmorRenderPipeline;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemDisplayContext;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -49,7 +50,8 @@ public class ItemRenderStateMixin {
     private void wrapSubmitItem(SubmitNodeCollector instance, PoseStack poseStack, ItemDisplayContext itemDisplayContext, int light, int overlay, int color, int[] tintLayers, List<BakedQuad> quads, RenderType renderType, ItemStackRenderState.FoilType foilType, Operation<Void> original) {
     //? if 1.21.9 || 1.21.10
     //private void wrapSubmitItem(SubmitNodeCollector instance, PoseStack poseStack, ItemDisplayContext itemDisplayContext, int light, int overlay, int color, int[] tintLayers, List<BakedQuad> quads, RenderType renderType, ItemStackRenderState.FoilType foilType, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND) && ArmorRenderPipeline.shouldModifyEquipment()) {
+            // Note to future me: This can actually hide main hands.
             float alpha = ArmorRenderPipeline.getTransparencyAlpha();
             //? if < 26.1-snapshot-7
             RenderType translucentType = ArmorRenderPipeline.getTranslucentItemRenderTypeIfApplicable(renderType);

--- a/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/ItemRendererMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/ItemRendererMixin.java
@@ -14,6 +14,7 @@ import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -29,7 +30,7 @@ public class ItemRendererMixin {
             )
     )
     private void wrapShieldRender(BlockEntityWithoutLevelRenderer instance, ItemStack itemStack, ItemDisplayContext ctx, PoseStack poseStack, MultiBufferSource bufferSource, int light, int overlay, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND) && ArmorRenderPipeline.shouldModifyEquipment()) {
             MultiBufferSource wrappedSource = renderType -> {
                 if (renderType == Sheets.shieldSheet()) {
                     return bufferSource.getBuffer(RenderType.entityTranslucent(Sheets.SHIELD_SHEET));
@@ -54,7 +55,7 @@ public class ItemRendererMixin {
     )
     private RenderType wrapGetRenderType(ItemStack itemStack, boolean fabulous, Operation<RenderType> original) {
         RenderType type = original.call(itemStack, fabulous);
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND) && ArmorRenderPipeline.shouldModifyEquipment()) {
             return ArmorRenderPipeline.getTranslucentItemRenderTypeIfApplicable(type);
         }
         return type;
@@ -69,7 +70,7 @@ public class ItemRendererMixin {
             )
     )
     private void wrapPutBulkData(VertexConsumer instance, PoseStack.Pose pose, BakedQuad quad, float r, float g, float b, float alpha, int light, int overlay, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND) && ArmorRenderPipeline.shouldModifyEquipment()) {
             float modifiedAlpha = alpha * ArmorRenderPipeline.getTransparencyAlpha();
             original.call(instance, pose, quad, r, g, b, modifiedAlpha, light, overlay);
         } else {
@@ -91,6 +92,7 @@ import de.zannagh.armorhider.rendering.ArmorRenderPipeline;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.world.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -109,7 +111,7 @@ public class ItemRendererMixin {
             argsOnly = true
     )
     private static RenderType modifyRenderType(RenderType renderType) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND) && ArmorRenderPipeline.shouldModifyEquipment()) {
             return ArmorRenderPipeline.getTranslucentItemRenderTypeIfApplicable(renderType);
         }
         return renderType;
@@ -123,7 +125,7 @@ public class ItemRendererMixin {
             )
     )
     private static void wrapPutBulkData(VertexConsumer instance, PoseStack.Pose pose, BakedQuad quad, float r, float g, float b, float alpha, int light, int overlay, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND) && ArmorRenderPipeline.shouldModifyEquipment()) {
             float modifiedAlpha = alpha * ArmorRenderPipeline.getTransparencyAlpha();
             original.call(instance, pose, quad, r, g, b, modifiedAlpha, light, overlay);
         } else {

--- a/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/ModelPartMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/ModelPartMixin.java
@@ -3,6 +3,7 @@
 
 import de.zannagh.armorhider.rendering.ArmorRenderPipeline;
 import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.world.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -19,7 +20,7 @@ public class ModelPartMixin {
             argsOnly = true
     )
     private int modifyRenderColor(int color) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND) && ArmorRenderPipeline.shouldModifyEquipment()) {
             return ArmorRenderPipeline.applyArmorTransparency(color);
         }
         return color;
@@ -34,7 +35,7 @@ public class ModelPartMixin {
             argsOnly = true
     )
     private float modifyRenderAlpha(float alpha) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND) && ArmorRenderPipeline.shouldModifyEquipment()) {
             return alpha * ArmorRenderPipeline.getTransparencyAlpha();
         }
         return alpha;

--- a/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/OffHandRenderMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/OffHandRenderMixin.java
@@ -71,7 +71,7 @@ public class OffHandRenderMixin {
     //private void modifyItemSubmit(ItemRenderer instance, LivingEntity livingEntity, ItemStack itemStack, ItemDisplayContext itemDisplayContext, boolean b, PoseStack poseStack, MultiBufferSource multiBufferSource, Level level, int i, int j, int k, Operation<Void> original) {
     //? if 1.21.5
     //private void modifyItemSubmit(ItemRenderer instance, LivingEntity livingEntity, ItemStack itemStack, ItemDisplayContext itemDisplayContext, PoseStack poseStack, MultiBufferSource multiBufferSource, Level level, int i, int j, int k, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext()
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND)
                 && ArmorRenderPipeline.shouldModifyEquipment()
                 && ArmorRenderPipeline.shouldHideEquipment()) {
             return;

--- a/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/SubmitNodeCollectorMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/mixin/client/hand/SubmitNodeCollectorMixin.java
@@ -42,7 +42,7 @@ public class SubmitNodeCollectorMixin {
     private void wrapModelPartAdd(ModelPartFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelPartSubmit submit, Operation<Void> original) {
     //? if 1.21.9 || 1.21.10
     //private void wrapModelPartAdd(ModelPartFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelPartSubmit submit, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext()
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND)
                 && ArmorRenderPipeline.shouldModifyEquipment()
                 && ArmorRenderPipeline.getCurrentModification() != null
                 && ArmorRenderPipeline.getCurrentModification().equipmentSlot() == EquipmentSlot.OFFHAND) {
@@ -94,7 +94,7 @@ public class SubmitNodeCollectorMixin {
     private <S> void wrapModelAdd(ModelFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelSubmit<S> submit, Operation<Void> original) {
     //? if 1.21.9 || 1.21.10
     //private <S> void wrapModelAdd(ModelFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelSubmit<S> submit, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext()
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.OFFHAND)
                 && ArmorRenderPipeline.shouldModifyEquipment()
                 && ArmorRenderPipeline.getCurrentModification() != null
                 && ArmorRenderPipeline.getCurrentModification().equipmentSlot() == EquipmentSlot.OFFHAND) {

--- a/common/src/client/java/de/zannagh/armorhider/mixin/client/head/SkullBlockRenderMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/mixin/client/head/SkullBlockRenderMixin.java
@@ -110,6 +110,7 @@ import net.minecraft.client.model.SkullModelBase;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.SkullBlockRenderer;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -123,7 +124,7 @@ public abstract class SkullBlockRenderMixin {
             )
     )
     private static void modifyTransparency(SkullModelBase instance, PoseStack poseStack, VertexConsumer vertexConsumer, int light, int overlay, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.HEAD) && ArmorRenderPipeline.shouldModifyEquipment()) {
             if (ArmorRenderPipeline.shouldHideEquipment()) {
                 return;
             }
@@ -159,6 +160,7 @@ import net.minecraft.client.model.SkullModelBase;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.SkullBlockRenderer;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -172,7 +174,7 @@ public abstract class SkullBlockRenderMixin {
             )
     )
     private static void modifyTransparency(SkullModelBase instance, PoseStack poseStack, VertexConsumer vertexConsumer, int light, int overlay, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.HEAD) && ArmorRenderPipeline.shouldModifyEquipment()) {
             if (ArmorRenderPipeline.shouldHideEquipment()) {
                 return;
             }
@@ -226,6 +228,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.SkullBlockRenderer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.SkullBlock;
+import net.minecraft.world.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -239,7 +242,7 @@ public abstract class SkullBlockRenderMixin {
             )
     )
     private static void modifyTransparency(SkullModelBase instance, PoseStack poseStack, VertexConsumer vertexConsumer, int light, int overlay, float red, float green, float blue, float alpha, Operation<Void> original) {
-        if (ArmorRenderPipeline.hasActiveContext() && ArmorRenderPipeline.shouldModifyEquipment()) {
+        if (ArmorRenderPipeline.hasActiveContext(EquipmentSlot.HEAD) && ArmorRenderPipeline.shouldModifyEquipment()) {
             if (!ArmorRenderPipeline.getCurrentModification().playerConfig().opacityAffectingHatOrSkull.getValue()) {
                 original.call(instance, poseStack, vertexConsumer, light, overlay, red, green, blue, alpha);
                 return;

--- a/common/src/client/java/de/zannagh/armorhider/rendering/ArmorRenderPipeline.java
+++ b/common/src/client/java/de/zannagh/armorhider/rendering/ArmorRenderPipeline.java
@@ -134,8 +134,11 @@ public class ArmorRenderPipeline {
         return !ArmorModificationContext.hasActiveContext();
     }
 
-    public static boolean hasActiveContext() {
-        return ArmorModificationContext.hasActiveContext();
+    public static boolean hasActiveContext(@Nullable EquipmentSlot slot) {
+        if (slot == null) {
+            return ArmorModificationContext.hasActiveContext();
+        }
+        return ArmorModificationContext.hasActiveContext() && ArmorModificationContext.getCurrentSlot() == slot;
     }
 
     public static void clearContext() {

--- a/neoforge/src/main/java/de/zannagh/armorhider/mixin/client/bodyKneesAndToes/NeoForgeArmorColorMixin.java
+++ b/neoforge/src/main/java/de/zannagh/armorhider/mixin/client/bodyKneesAndToes/NeoForgeArmorColorMixin.java
@@ -118,7 +118,7 @@ public class NeoForgeArmorColorMixin {
     }
 
     private static boolean shouldApplyArmorTransparency() {
-        return ArmorRenderPipeline.hasActiveContext()
+        return ArmorRenderPipeline.hasActiveContext(null)
                 && ArmorRenderPipeline.shouldModifyEquipment()
                 && ArmorRenderPipeline.getCurrentModification() != null
                 && ArmorRenderPipeline.getCurrentModification().equipmentSlot() != EquipmentSlot.OFFHAND;


### PR DESCRIPTION
See #101 for detailed description.

Helmet context was leaking into the offhand interception and the 'submitItem' mixin can effectively hide any item. Added an additional parameter for ArmorRenderPipeline.hasActiveContext() which tests for the targeted slot (can be overridden with null) which lazily fixes the issue. 