### PR TITLE
fix: extractRenderState to enter render scope

### DIFF
--- a/common/src/client/java/de/zannagh/armorhider/mixin/client/LivingEntityRendererMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/mixin/client/LivingEntityRendererMixin.java
@@ -1,6 +1,7 @@
 //? if >= 1.21.4 {
 package de.zannagh.armorhider.mixin.client;
 
+import de.zannagh.armorhider.client.ArmorHiderClient;
 import de.zannagh.armorhider.scopes.EntityIdentityResolver;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
@@ -19,9 +20,34 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * but also for sneaking players, invisible players, and players with hidden nametags
  * (e.g. team settings). Without this hint, the identity resolver would incorrectly
  * treat all null-nameTag players as the local player.
+ * <p>
+ * In 1.21.9+, {@code extractRenderState} and {@code EntityRenderDispatcher.submit} are
+ * separate phases. The entity render scope (set by {@code EntityRenderDispatcherMixin}) only
+ * starts at {@code submit}, so during extraction {@code isInEntityRender()} is false.
+ * This causes {@code EquipmentSlotHidingMixin} to fire during extraction, potentially
+ * hiding items from the render state before layers ever see them. We enter the entity render
+ * scope at HEAD of extraction to prevent this.
  */
 @Mixin(LivingEntityRenderer.class)
 public class LivingEntityRendererMixin {
+
+    /**
+     * Enters the entity render scope during {@code extractRenderState} so that
+     * {@link de.zannagh.armorhider.mixin.client.EquipmentSlotHidingMixin} does not
+     * intercept {@code getItemBySlot} calls made by vanilla during state extraction.
+     * <p>
+     * In 1.21.4–1.21.8 this is redundant (the scope is already entered by
+     * {@code EntityRenderDispatcherMixin} which hooks the wrapping {@code render(Entity)} method),
+     * but harmless — {@code enterEntityRender()} simply resets to SENTINEL.
+     * In 1.21.9+ it is required because {@code submit(EntityRenderState)} is a separate call.
+     */
+    @Inject(
+            method = "extractRenderState(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;F)V",
+            at = @At("HEAD")
+    )
+    private void enterEntityRenderDuringExtraction(LivingEntity entity, LivingEntityRenderState state, float partialTick, CallbackInfo ci) {
+        ArmorHiderClient.SCOPE_PROVIDER.enterEntityRender();
+    }
 
     @Inject(
             method = "extractRenderState(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;F)V",


### PR DESCRIPTION
 This should prevent EquipmentSlotHidingMixin from hiding items before layers see them
