### PR TITLE
fix: version range on prereleases for 26.1, fixes #136

### DIFF
--- a/fabric/versions/fabric-26.1-pre-1/gradle.properties
+++ b/fabric/versions/fabric-26.1-pre-1/gradle.properties
@@ -1,4 +1,4 @@
 java.version=25
-fabric.minecraft_version_range=26.1-
+fabric.minecraft_version_range=<=26.1-pre.2
 fabric.minecraft_version=26.1-pre.1
 display_version=mc-26.1-pre.1-2

--- a/fabric/versions/fabric-26.1-pre-2/gradle.properties
+++ b/fabric/versions/fabric-26.1-pre-2/gradle.properties
@@ -1,4 +1,4 @@
 java.version=25
-fabric.minecraft_version_range=26.1-
+fabric.minecraft_version_range=<=26.1-pre.2
 fabric.minecraft_version=26.1-pre.2
 display_version=mc-26.1-pre.1-2


### PR DESCRIPTION
* replaces the version condition with a simple <= evaluation