### PR TITLE
refactor: use version ranged stonecutter branches

### DIFF
--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/PlayerModelMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/PlayerModelMixin.java
@@ -1,3 +1,4 @@
+//? if >= 1.21.10 {
 package de.zannagh.armorhider.client.mixin;
 
 import de.zannagh.armorhider.client.ArmorHiderClient;
@@ -18,7 +19,6 @@ This mixin purely exists to reset the visible setting of FantasyArmor on 1.21.10
  */
 @Mixin(PlayerModel.class)
 public class PlayerModelMixin {
-    //? if >= 1.21.10 {
     @Inject(
             method = "setupAnim(Ljava/lang/Object;)V",
             //? if fabric
@@ -28,7 +28,6 @@ public class PlayerModelMixin {
     private void setupAnim(Object state, CallbackInfo ci) {
         resetArmVisibility(state);
     }
-    //?}
 
     @Unique
     private void resetArmVisibility(Object state) {
@@ -55,3 +54,4 @@ public class PlayerModelMixin {
         }
     }
 }
+//?}

--- a/common/versions/fabric-1.20/gradle.properties
+++ b/common/versions/fabric-1.20/gradle.properties
@@ -1,4 +1,0 @@
-java.version=17
-display_version=mc-1.20.0-1
-elytratrims.version=9K6nhsb4
-geckolib.version=V5QnDeov

--- a/common/versions/fabric-1.21.5/gradle.properties
+++ b/common/versions/fabric-1.21.5/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-display_version=mc-1.21.5-8
-elytratrims.version=Uj37Za5k
-geckolib.version=AyXpbm2h

--- a/common/versions/fabric-1.21.6/gradle.properties
+++ b/common/versions/fabric-1.21.6/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-display_version=mc-1.21.5-8
-elytratrims.version=QklJxw1S
-geckolib.version=cMt8HLkd

--- a/common/versions/fabric-1.21.7/gradle.properties
+++ b/common/versions/fabric-1.21.7/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-display_version=mc-1.21.5-8
-elytratrims.version=QklJxw1S
-geckolib.version=k4Azk0wN

--- a/common/versions/fabric-1.21.9/gradle.properties
+++ b/common/versions/fabric-1.21.9/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-display_version=mc-1.21.9-10
-elytratrims.version=iLC0LP3D
-geckolib.version=7qjQQSWv

--- a/common/versions/fabric-1.21/gradle.properties
+++ b/common/versions/fabric-1.21/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-display_version=mc-1.21.0-1
-elytratrims.version=KOEvdSw7
-geckolib.version=11VBhLU2

--- a/common/versions/fabric-26.1.1/gradle.properties
+++ b/common/versions/fabric-26.1.1/gradle.properties
@@ -1,4 +1,0 @@
-java.version=25
-display_version=mc-26.1.0-2
-elytratrims.version=NLOF6eKu
-geckolib.version=yUpAp23B

--- a/common/versions/fabric-26.1/gradle.properties
+++ b/common/versions/fabric-26.1/gradle.properties
@@ -1,4 +1,0 @@
-java.version=25
-display_version=mc-26.1.0-2
-elytratrims.version=NLOF6eKu
-geckolib.version=yUpAp23B

--- a/common/versions/neoforge-1.21.5/gradle.properties
+++ b/common/versions/neoforge-1.21.5/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-display_version=mc-1.21.5-8
-geckolib.version=GbxHZH7t
-elytratrims.version=pE9aHfFz

--- a/common/versions/neoforge-1.21.6/gradle.properties
+++ b/common/versions/neoforge-1.21.6/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-display_version=mc-1.21.5-8
-geckolib.version=faqm9u5p
-elytratrims.version=RMLnPwtS

--- a/common/versions/neoforge-1.21.7/gradle.properties
+++ b/common/versions/neoforge-1.21.7/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-display_version=mc-1.21.5-8
-geckolib.version=U4DFMhQx
-elytratrims.version=RMLnPwtS

--- a/common/versions/neoforge-1.21.9/gradle.properties
+++ b/common/versions/neoforge-1.21.9/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-display_version=mc-1.21.9-10
-geckolib.version=xji1VqGU
-elytratrims.version=GxM8lsm4

--- a/common/versions/neoforge-1.21/gradle.properties
+++ b/common/versions/neoforge-1.21/gradle.properties
@@ -1,6 +1,0 @@
-java.version=21
-neoforge.version=21.0.167
-neoforge.minecraft_version_range=[1.21,1.21.1]
-display_version=mc-1.21.0-1
-geckolib.version=UvKZBX05
-elytratrims.version=7mqA6CJO

--- a/common/versions/neoforge-26.1.1/gradle.properties
+++ b/common/versions/neoforge-26.1.1/gradle.properties
@@ -1,4 +1,0 @@
-java.version=25
-display_version=mc-26.1.0-2
-geckolib.version=ScUAwGRA
-elytratrims.version=wgUBgHvL

--- a/common/versions/neoforge-26.1/gradle.properties
+++ b/common/versions/neoforge-26.1/gradle.properties
@@ -1,4 +1,0 @@
-java.version=25
-display_version=mc-26.1.0-2
-geckolib.version=ScUAwGRA
-elytratrims.version=wgUBgHvL

--- a/fabric/versions/fabric-1.20.1/gradle.properties
+++ b/fabric/versions/fabric-1.20.1/gradle.properties
@@ -2,3 +2,4 @@ java.version=17
 fabric.minecraft_version_range=>=1.20 <=1.20.1
 fabric.minecraft_version=1.20.1
 display_version=mc-1.20.0-1
+game_versions=1.20,1.20.1

--- a/fabric/versions/fabric-1.20/gradle.properties
+++ b/fabric/versions/fabric-1.20/gradle.properties
@@ -1,4 +1,0 @@
-java.version=17
-fabric.minecraft_version_range=>=1.20 <=1.20.1
-fabric.minecraft_version=1.20
-display_version=mc-1.20.0-1

--- a/fabric/versions/fabric-1.21.1/gradle.properties
+++ b/fabric/versions/fabric-1.21.1/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 fabric.minecraft_version_range=>=1.21 <=1.21.1
 fabric.minecraft_version=1.21.1
 display_version=mc-1.21.0-1
+game_versions=1.21,1.21.1

--- a/fabric/versions/fabric-1.21.10/gradle.properties
+++ b/fabric/versions/fabric-1.21.10/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 fabric.minecraft_version_range=>=1.21.9 <=1.21.10
 fabric.minecraft_version=1.21.10
 display_version=mc-1.21.9-10
+game_versions=1.21.9,1.21.10

--- a/fabric/versions/fabric-1.21.11/gradle.properties
+++ b/fabric/versions/fabric-1.21.11/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 fabric.minecraft_version_range=1.21.11
 fabric.minecraft_version=1.21.11
 display_version=mc-1.21.11
+game_versions=1.21.11

--- a/fabric/versions/fabric-1.21.4/gradle.properties
+++ b/fabric/versions/fabric-1.21.4/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 fabric.minecraft_version_range=>=1.21.4 <=1.21.4
 fabric.minecraft_version=1.21.4
 display_version=mc-1.21.4
+game_versions=1.21.4

--- a/fabric/versions/fabric-1.21.5/gradle.properties
+++ b/fabric/versions/fabric-1.21.5/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-fabric.minecraft_version_range=>=1.21.5 <=1.21.8
-fabric.minecraft_version=1.21.5
-display_version=mc-1.21.5-8

--- a/fabric/versions/fabric-1.21.6/gradle.properties
+++ b/fabric/versions/fabric-1.21.6/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-fabric.minecraft_version_range=>=1.21.5 <=1.21.8
-fabric.minecraft_version=1.21.6
-display_version=mc-1.21.5-8

--- a/fabric/versions/fabric-1.21.7/gradle.properties
+++ b/fabric/versions/fabric-1.21.7/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-fabric.minecraft_version_range=>=1.21.5 <=1.21.8
-fabric.minecraft_version=1.21.7
-display_version=mc-1.21.5-8

--- a/fabric/versions/fabric-1.21.8/gradle.properties
+++ b/fabric/versions/fabric-1.21.8/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 fabric.minecraft_version_range=>=1.21.5 <=1.21.8
 fabric.minecraft_version=1.21.8
 display_version=mc-1.21.5-8
+game_versions=1.21.5,1.21.6,1.21.7,1.21.8

--- a/fabric/versions/fabric-1.21.9/gradle.properties
+++ b/fabric/versions/fabric-1.21.9/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-fabric.minecraft_version_range=>=1.21.9 <=1.21.10
-fabric.minecraft_version=1.21.9
-display_version=mc-1.21.9-10

--- a/fabric/versions/fabric-1.21/gradle.properties
+++ b/fabric/versions/fabric-1.21/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-fabric.minecraft_version_range=>=1.21 <=1.21.1
-fabric.minecraft_version=1.21
-display_version=mc-1.21.0-1

--- a/fabric/versions/fabric-26.1-pre-2/gradle.properties
+++ b/fabric/versions/fabric-26.1-pre-2/gradle.properties
@@ -2,3 +2,4 @@ java.version=25
 fabric.minecraft_version_range=<=26.1-pre.2
 fabric.minecraft_version=26.1-pre.2
 display_version=mc-26.1-pre.1-2
+game_versions=26.1-pre-1,26.1-pre-2

--- a/fabric/versions/fabric-26.1-rc-1/gradle.properties
+++ b/fabric/versions/fabric-26.1-rc-1/gradle.properties
@@ -2,3 +2,4 @@ java.version=25
 fabric.minecraft_version_range=<=26.1-rc.2
 fabric.minecraft_version=26.1-rc.1
 display_version=mc-26.1-rc.1-2
+game_versions=26.1-rc-1,26.1-rc-2

--- a/fabric/versions/fabric-26.1-rc-2/gradle.properties
+++ b/fabric/versions/fabric-26.1-rc-2/gradle.properties
@@ -2,3 +2,4 @@ java.version=25
 fabric.minecraft_version_range=<=26.1-rc.2
 fabric.minecraft_version=26.1-rc.2
 display_version=mc-26.1-rc.1-2
+game_versions=26.1-rc-1,26.1-rc-2

--- a/fabric/versions/fabric-26.1-snapshot-11/gradle.properties
+++ b/fabric/versions/fabric-26.1-snapshot-11/gradle.properties
@@ -2,3 +2,4 @@ java.version=25
 fabric.minecraft_version_range=>=26.1-alpha.7 <=26.1-alpha.11
 fabric.minecraft_version=26.1-alpha.11
 display_version=26.1-snap.7-11
+game_versions=26.1-snapshot-7,26.1-snapshot-8,26.1-snapshot-9,26.1-snapshot-10,26.1-snapshot-11

--- a/fabric/versions/fabric-26.1.1/gradle.properties
+++ b/fabric/versions/fabric-26.1.1/gradle.properties
@@ -1,6 +1,0 @@
-java.version=25
-fabric.minecraft_version_range=>=26.1 <=26.1.2
-fabric.minecraft_version=26.1.1
-display_version=mc-26.1.0-2
-# For wildfire compat testing, we need 0.18.4 fabric loader
-loader_version=0.18.4

--- a/fabric/versions/fabric-26.1.2/gradle.properties
+++ b/fabric/versions/fabric-26.1.2/gradle.properties
@@ -2,5 +2,6 @@ java.version=25
 fabric.minecraft_version_range=>=26.1 <=26.1.2
 fabric.minecraft_version=26.1.2
 display_version=mc-26.1.0-2
+game_versions=26.1,26.1.1,26.1.2
 # For wildfire compat testing, we need 0.18.4 fabric loader
 loader_version=0.18.4

--- a/fabric/versions/fabric-26.1/gradle.properties
+++ b/fabric/versions/fabric-26.1/gradle.properties
@@ -1,6 +1,0 @@
-java.version=25
-fabric.minecraft_version_range=>=26.1 <=26.1.2
-fabric.minecraft_version=26.1
-display_version=mc-26.1.0-2
-# For wildfire compat testing, we need 0.18.4 fabric loader
-loader_version=0.18.4

--- a/neoforge/versions/neoforge-1.21.1/gradle.properties
+++ b/neoforge/versions/neoforge-1.21.1/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 neoforge.version=21.1.219
 neoforge.minecraft_version_range=[1.21,1.21.1]
 display_version=mc-1.21.0-1
+game_versions=1.21,1.21.1

--- a/neoforge/versions/neoforge-1.21.10/gradle.properties
+++ b/neoforge/versions/neoforge-1.21.10/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 neoforge.version=21.10.64
 neoforge.minecraft_version_range=[1.21.9,1.21.10]
 display_version=mc-1.21.9-10
+game_versions=1.21.9,1.21.10

--- a/neoforge/versions/neoforge-1.21.11/gradle.properties
+++ b/neoforge/versions/neoforge-1.21.11/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 neoforge.version=21.11.42
 neoforge.minecraft_version_range=[1.21.11]
 display_version=mc-1.21.11
+game_versions=1.21.11

--- a/neoforge/versions/neoforge-1.21.4/gradle.properties
+++ b/neoforge/versions/neoforge-1.21.4/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 neoforge.version=21.4.156
 neoforge.minecraft_version_range=[1.21.4]
 display_version=mc-1.21.4
+game_versions=1.21.4

--- a/neoforge/versions/neoforge-1.21.5/gradle.properties
+++ b/neoforge/versions/neoforge-1.21.5/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-neoforge.version=21.5.96
-neoforge.minecraft_version_range=[1.21.5,1.21.8]
-display_version=mc-1.21.5-8

--- a/neoforge/versions/neoforge-1.21.6/gradle.properties
+++ b/neoforge/versions/neoforge-1.21.6/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-neoforge.version=21.6.20-beta
-neoforge.minecraft_version_range=[1.21.5,1.21.8]
-display_version=mc-1.21.5-8

--- a/neoforge/versions/neoforge-1.21.7/gradle.properties
+++ b/neoforge/versions/neoforge-1.21.7/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-neoforge.version=21.7.25-beta
-neoforge.minecraft_version_range=[1.21.5,1.21.8]
-display_version=mc-1.21.5-8

--- a/neoforge/versions/neoforge-1.21.8/gradle.properties
+++ b/neoforge/versions/neoforge-1.21.8/gradle.properties
@@ -2,3 +2,4 @@ java.version=21
 neoforge.version=21.8.52
 neoforge.minecraft_version_range=[1.21.5,1.21.8]
 display_version=mc-1.21.5-8
+game_versions=1.21.5,1.21.6,1.21.7,1.21.8

--- a/neoforge/versions/neoforge-1.21.9/gradle.properties
+++ b/neoforge/versions/neoforge-1.21.9/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-neoforge.version=21.9.16-beta
-neoforge.minecraft_version_range=[1.21.9,1.21.10]
-display_version=mc-1.21.9-10

--- a/neoforge/versions/neoforge-1.21/gradle.properties
+++ b/neoforge/versions/neoforge-1.21/gradle.properties
@@ -1,4 +1,0 @@
-java.version=21
-neoforge.version=21.0.167
-neoforge.minecraft_version_range=[1.21,1.21.1]
-display_version=mc-1.21.0-1

--- a/neoforge/versions/neoforge-26.1.1/gradle.properties
+++ b/neoforge/versions/neoforge-26.1.1/gradle.properties
@@ -1,4 +1,0 @@
-java.version=25
-neoforge.version=26.1.1.2-beta
-neoforge.minecraft_version_range=[26.1,26.1.2]
-display_version=mc-26.1.0-2

--- a/neoforge/versions/neoforge-26.1.2/gradle.properties
+++ b/neoforge/versions/neoforge-26.1.2/gradle.properties
@@ -2,3 +2,4 @@ java.version=25
 neoforge.version=26.1.1.11-beta
 neoforge.minecraft_version_range=[26.1,26.1.2]
 display_version=mc-26.1.0-2
+game_versions=26.1,26.1.1,26.1.2

--- a/neoforge/versions/neoforge-26.1/gradle.properties
+++ b/neoforge/versions/neoforge-26.1/gradle.properties
@@ -1,4 +1,0 @@
-java.version=25
-neoforge.version=26.1.0.8-beta
-neoforge.minecraft_version_range=[26.1,26.1.2]
-display_version=mc-26.1.0-2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,19 +18,19 @@ stonecutter {
     centralScript = "build.gradle.kts"
     
     val fabricVersions = listOf(
-        "1.20", "1.20.1",
-        "1.21", "1.21.1",
-        "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8",
-        "1.21.9", "1.21.10", "1.21.11",
+        "1.20.1",
+        "1.21.1",
+        "1.21.4", "1.21.8",
+        "1.21.10", "1.21.11",
         "26.1-snapshot-11",
         "26.1-pre-2",
         "26.1-rc-1", "26.1-rc-2",
-        "26.1", "26.1.1", "26.1.2"
+        "26.1.2"
     )
     val neoforgeVersions = listOf(
-        "1.21", "1.21.1", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8",
-        "1.21.9", "1.21.10", "1.21.11",
-        "26.1", "26.1.1", "26.1.2"
+        "1.21.1", "1.21.4", "1.21.8",
+        "1.21.10", "1.21.11",
+        "26.1.2"
     )
 
     // Required to have a parseable semVer for StoneCutter (26.1-0.snapshot.2 instead of 26.1-snapshot-2)
@@ -43,7 +43,7 @@ stonecutter {
         .replace(Regex("rc-(\\d+)"), "2.rc.$1")
 
     create(rootProject) {
-        vcsVersion = "fabric-26.1" // Latest stable
+        vcsVersion = "fabric-26.1.2" // Latest stable
 
         branch("common") {
             fabricVersions.forEach { version("fabric-$it", semver(it)) }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -30,17 +30,20 @@ tasks.register("stageArtifacts") {
             }
             val displayVersion = props.getProperty("display_version") ?: return@forEach
             val gameVersions = props.getProperty("game_versions")
-                ?.split(",")?.map { it.trim() }
-                ?: return@forEach
+                ?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
+                ?: error("Missing game_versions in ${versionDir.name}/gradle.properties")
             val dirName = versionDir.name // e.g. "fabric-1.20.1"
             val loader = dirName.substringBefore("-")
-            versionMap.getOrPut(loader) { mutableMapOf() }
+            val existing = versionMap.getOrPut(loader) { mutableMapOf() }
                 .putIfAbsent(displayVersion, gameVersions)
+            if (existing != null && existing.sorted() != gameVersions.sorted()) {
+                error("Conflicting game_versions for $loader/$displayVersion: $existing vs $gameVersions")
+            }
         }
     }
     val versionMapJson = versionMap.entries.sortedBy { it.key }.joinToString(",\n  ", "{\n  ", "\n}") { (loader, groups) ->
         val groupsJson = groups.entries.sortedBy { it.key }.joinToString(",\n    ", "{\n    ", "\n  }") { (display, versions) ->
-            val versionsJson = versions.joinToString("\", \"", "[\"", "\"]")
+            val versionsJson = versions.sorted().joinToString("\", \"", "[\"", "\"]")
             "\"$display\": $versionsJson"
         }
         "\"$loader\": $groupsJson"

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -19,8 +19,8 @@ tasks.register("stageArtifacts") {
     val staging = rootProject.file("staging")
     val versionDirs = listOf("fabric/versions", "neoforge/versions").map { rootProject.file(it) }
 
-    // Build the version map from gradle.properties: { loader: { displayVersion: [mcVersion, ...] } }
-    val versionMap = mutableMapOf<String, MutableMap<String, MutableList<String>>>()
+    // Build the version map from gradle.properties: { loader: { displayVersion: [gameVersion, ...] } }
+    val versionMap = mutableMapOf<String, MutableMap<String, List<String>>>()
     for (loaderDir in versionDirs) {
         loaderDir.listFiles()?.filter { it.isDirectory }?.forEach { versionDir ->
             val props = java.util.Properties()
@@ -29,18 +29,18 @@ tasks.register("stageArtifacts") {
                 propsFile.reader().use { props.load(it) }
             }
             val displayVersion = props.getProperty("display_version") ?: return@forEach
-            val dirName = versionDir.name // e.g. "fabric-1.20"
+            val gameVersions = props.getProperty("game_versions")
+                ?.split(",")?.map { it.trim() }
+                ?: return@forEach
+            val dirName = versionDir.name // e.g. "fabric-1.20.1"
             val loader = dirName.substringBefore("-")
-            val mcVersion = dirName.substringAfter("$loader-")
             versionMap.getOrPut(loader) { mutableMapOf() }
-                .getOrPut(displayVersion) { mutableListOf() }
-                .add(mcVersion)
+                .putIfAbsent(displayVersion, gameVersions)
         }
     }
     val versionMapJson = versionMap.entries.sortedBy { it.key }.joinToString(",\n  ", "{\n  ", "\n}") { (loader, groups) ->
         val groupsJson = groups.entries.sortedBy { it.key }.joinToString(",\n    ", "{\n    ", "\n  }") { (display, versions) ->
-            val versionsJson = if (versions.size == 1 && versions[0] == display) "null"
-            else versions.sorted().joinToString("\", \"", "[\"", "\"]")
+            val versionsJson = versions.joinToString("\", \"", "[\"", "\"]")
             "\"$display\": $versionsJson"
         }
         "\"$loader\": $groupsJson"

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("net.neoforged.moddev") version "2.0.140" apply false
 }
 
-stonecutter active "fabric-26.1" /* [SC] DO NOT EDIT */
+stonecutter active "fabric-26.1.2" /* [SC] DO NOT EDIT */
 
 tasks.register("stageArtifacts") {
     group = "build"


### PR DESCRIPTION
* remove individual versions for each game version and instead configure stonecutter branches with version ranges to reduce the amount of individual build tasks