### PR TITLE
fix: early classload when setting compat flags

### DIFF
--- a/common/src/main/java/de/zannagh/armorhider/CompatFlags.java
+++ b/common/src/main/java/de/zannagh/armorhider/CompatFlags.java
@@ -4,10 +4,9 @@ package de.zannagh.armorhider;
  * Lightweight compat flags set during mixin plugin load — before MC classes are available.
  * This class must NOT import any Minecraft classes to avoid early class loading.
  *
- * <p>Flags are set by each loader's {@code MixinPlugin.onLoad()} using the loader's
- * native mod detection API (FabricLoader / classExists on NeoForge).
- * {@link de.zannagh.armorhider.client.ArmorHiderClient} reads these with a
- * {@code classExists} fallback for safety.</p>
+ * <p>Flags are set via {@link de.zannagh.armorhider.util.MixinUtil#setCompatFlags}
+ * using resource-based probing (never {@code Class.forName}) to avoid premature
+ * class loading that breaks other mods' mixins.</p>
  */
 public final class CompatFlags {
 

--- a/common/src/main/java/de/zannagh/armorhider/util/MixinUtil.java
+++ b/common/src/main/java/de/zannagh/armorhider/util/MixinUtil.java
@@ -1,12 +1,14 @@
 package de.zannagh.armorhider.util;
 
 import de.zannagh.armorhider.ArmorHider;
+import de.zannagh.armorhider.CompatFlags;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 public final class MixinUtil {
-    
+
     public static List<String> getMixinClassesWherePresent(String packageName, List<String> expectedClasses) {
         var list = new ArrayList<String>();
         for (String mixin : expectedClasses) {
@@ -21,5 +23,45 @@ public final class MixinUtil {
         }
 
         return list;
+    }
+
+    /**
+     * Sets compat flags by probing for mod presence via resource checks (never {@code Class.forName}).
+     * Each probe first checks the exact class, then falls back to checking whether the mod's
+     * package directory exists (2nd and 3rd dot-separated segments, e.g. {@code bernie/geckolib}
+     * from {@code software.bernie.geckolib.renderer.GeoArmorRenderer}).
+     *
+     * @param cl the classloader to probe (usually the MixinPlugin's own classloader)
+     */
+    public static void setCompatFlags(ClassLoader cl) {
+        CompatFlags.ET_LOADED = isModPresent(cl, "dev.kikugie.elytratrims.ep.ETClientEntrypoint");
+        CompatFlags.GECKOLIB_LOADED = isModPresent(cl, "software.bernie.geckolib.renderer.GeoArmorRenderer");
+        CompatFlags.FA_LOADED = isModPresent(cl, "net.kenddie.fantasyarmor.FantasyArmor");
+        CompatFlags.WFGM_LOADED = isModPresent(cl, "com.wildfire.render.GenderArmorLayer");
+    }
+
+    /**
+     * Checks whether a mod is present without loading any classes.
+     * <ol>
+     *   <li>Probes for the exact {@code .class} resource.</li>
+     *   <li>Falls back to checking the package directory formed by the 2nd and 3rd
+     *       dot-separated segments (the org/mod identifier that is unlikely to change
+     *       even when individual classes are renamed).</li>
+     * </ol>
+     */
+    public static boolean isModPresent(ClassLoader cl, String className) {
+        if (cl.getResource(className.replace('.', '/') + ".class") != null) {
+            return true;
+        }
+        String[] parts = className.split("\\.");
+        if (parts.length >= 3) {
+            String packageProbe = parts[1] + "/" + parts[2];
+            try {
+                return cl.getResources(packageProbe).hasMoreElements();
+            } catch (IOException e) {
+                return false;
+            }
+        }
+        return false;
     }
 }

--- a/common/src/main/java/de/zannagh/armorhider/util/MixinUtil.java
+++ b/common/src/main/java/de/zannagh/armorhider/util/MixinUtil.java
@@ -55,10 +55,11 @@ public final class MixinUtil {
         }
         String[] parts = className.split("\\.");
         if (parts.length >= 3) {
-            String packageProbe = parts[1] + "/" + parts[2];
+            String packageProbe = parts[1] + "/" + parts[2] + "/";
             try {
                 return cl.getResources(packageProbe).hasMoreElements();
             } catch (IOException e) {
+                ArmorHider.LOGGER.debug("Failed to probe package resource '{}'.", packageProbe, e);
                 return false;
             }
         }

--- a/fabric/src/client/java/de/zannagh/armorhider/client/MixinPlugin.java
+++ b/fabric/src/client/java/de/zannagh/armorhider/client/MixinPlugin.java
@@ -1,8 +1,6 @@
 package de.zannagh.armorhider.client;
 
-import de.zannagh.armorhider.CompatFlags;
 import de.zannagh.armorhider.util.MixinUtil;
-import net.fabricmc.loader.api.FabricLoader;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
@@ -78,11 +76,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public void onLoad(String mixinPackage) {
-        var loader = FabricLoader.getInstance();
-        if (loader.isModLoaded("elytratrims")) CompatFlags.ET_LOADED = true;
-        if (loader.isModLoaded("geckolib")) CompatFlags.GECKOLIB_LOADED = true;
-        if (loader.isModLoaded("fantasy_armor")) CompatFlags.FA_LOADED = true;
-        if (loader.isModLoaded("wildfire_gender")) CompatFlags.WFGM_LOADED = true;
+        MixinUtil.setCompatFlags(MixinPlugin.class.getClassLoader());
     }
 
     @Override

--- a/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
+++ b/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
@@ -67,10 +67,15 @@ public class MixinPlugin implements IMixinConfigPlugin {
     @Override
     public List<String> getMixins() {
         //? if >= 1.21.9 {
-        if (FMLEnvironment.getDist() == Dist.DEDICATED_SERVER) return List.of();
+        if (FMLEnvironment.getDist() == Dist.DEDICATED_SERVER) {
+            return List.of();
+        }
         //?} else {
-        /*if (FMLEnvironment.dist == Dist.DEDICATED_SERVER) return List.of();*/
-        //?}
+        /*
+        if (FMLEnvironment.dist == Dist.DEDICATED_SERVER) { 
+            return List.of();
+        }
+        *///?}
         var mixinsToAdd = new ArrayList<>(List.of(MIXINS));
         return MixinUtil.getMixinClassesWherePresent(PACKAGE, mixinsToAdd);
     }
@@ -86,19 +91,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public void onLoad(String mixinPackage) {
-        if (classExists("dev.kikugie.elytratrims.ep.ETClientEntrypoint")) CompatFlags.ET_LOADED = true;
-        if (classExists("software.bernie.geckolib.renderer.GeoArmorRenderer")) CompatFlags.GECKOLIB_LOADED = true;
-        if (classExists("net.kenddie.fantasyarmor.FantasyArmor")) CompatFlags.FA_LOADED = true;
-        if (classExists("com.wildfire.render.GenderArmorLayer")) CompatFlags.WFGM_LOADED = true;
-    }
-
-    private static boolean classExists(String name) {
-        try {
-            Class.forName(name, false, MixinPlugin.class.getClassLoader());
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
+        MixinUtil.setCompatFlags(MixinPlugin.class.getClassLoader());
     }
 
     @Override

--- a/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
+++ b/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
@@ -1,6 +1,5 @@
 package de.zannagh.armorhider.client;
 
-import de.zannagh.armorhider.CompatFlags;
 import de.zannagh.armorhider.util.MixinUtil;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.loading.FMLEnvironment;


### PR DESCRIPTION
This fixes the mod causing an early classload (transiently, when a probed mod extends a specific class) which in turn makes the game crash during mixin resolution.
Instead of classloading, this sets the compat flags by probing class names and package names as resources.