### PR TITLE
fix: unify player name resolution throughout the mod, fixes #189

### DIFF
--- a/common/src/client/java/de/zannagh/armorhider/client/ArmorHiderClient.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/ArmorHiderClient.java
@@ -6,11 +6,11 @@ import de.zannagh.armorhider.client.gui.screens.ArmorHiderOptionsScreen;
 import de.zannagh.armorhider.client.net.ClientCommunicationManager;
 import de.zannagh.armorhider.client.scopes.RenderContext;
 import de.zannagh.armorhider.log.DebugLogger;
+import de.zannagh.armorhider.util.PlayerNameUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NonNull;
@@ -70,12 +70,8 @@ public class ArmorHiderClient {
     }
 
     public static String getCurrentPlayerName() {
-        Player clientPlayer = Minecraft.getInstance().player;
-        if (clientPlayer == null) {
-            return ClientConfigManager.DEFAULT_PLAYER_NAME;
-        }
-        Component displayText = clientPlayer.getDisplayName();
-        return displayText.getString().isEmpty() ? ClientConfigManager.DEFAULT_PLAYER_NAME : displayText.getString();
+        String name = PlayerNameUtil.getPlayerName(Minecraft.getInstance().player);
+        return name != null ? name : ClientConfigManager.DEFAULT_PLAYER_NAME;
     }
 
     @Contract("_ -> new")
@@ -91,14 +87,19 @@ public class ArmorHiderClient {
         if (entry == null) {
             return new Pair<>(false, null);
         }
-        //? if >= 1.21.9
-        String profileName = entry.getProfile().name();
-        //? if < 1.21.9
-        //String profileName = entry.getProfile().getName();
-        if (profileName == null) {
+        Player localPlayer = Minecraft.getInstance().player;
+        if (localPlayer == null) {
             return new Pair<>(false, null);
         }
-        return new Pair<>(!profileName.equals(getCurrentPlayerName()), entry);
+        //? if >= 1.21.9 {
+        boolean isLocal = entry.getProfile().id().equals(localPlayer.getUUID())
+                || playerName.equals(entry.getProfile().name());
+        //?}
+        //? if < 1.21.9 {
+        /*boolean isLocal = entry.getProfile().getId().equals(localPlayer.getUUID())
+                || playerName.equals(entry.getProfile().getName());
+        *///?}
+        return new Pair<>(!isLocal, entry);
     }
     
     public static void toggleDebugLogging() {

--- a/common/src/client/java/de/zannagh/armorhider/client/combat/ClientCombatManager.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/combat/ClientCombatManager.java
@@ -4,6 +4,7 @@ import de.zannagh.armorhider.client.ArmorHiderClient;
 import de.zannagh.armorhider.client.net.ClientPacketSender;
 import de.zannagh.armorhider.combat.CombatManager;
 import de.zannagh.armorhider.net.packets.CombatLogEventPacket;
+import de.zannagh.armorhider.util.PlayerNameUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.RemotePlayer;
@@ -16,14 +17,14 @@ import java.util.function.Function;
 public final class ClientCombatManager {
     public static void handleCombat(Function<Player, Boolean> shouldLogCombat, DamageSource damageSource, @Nullable Player victim) {
         if (victim != null && shouldLogCombat.apply(victim)) {
-            CombatManager.logCombat(victim.getDisplayName().getString());
+            CombatManager.logCombat(PlayerNameUtil.getPlayerName(victim));
             if (Minecraft.getInstance().player != null) {
                 ClientPacketSender.sendToServer(new CombatLogEventPacket(victim, Minecraft.getInstance().player.getUUID()));
             }
         }
 
         if (damageSource.getEntity() instanceof AbstractClientPlayer attacker && shouldLogCombat.apply(attacker)) {
-            CombatManager.logCombat(attacker.getDisplayName().getString());
+            CombatManager.logCombat(PlayerNameUtil.getPlayerName(attacker));
             if (Minecraft.getInstance().player != null) {
                 ClientPacketSender.sendToServer(new CombatLogEventPacket(attacker, Minecraft.getInstance().player.getUUID()));
             }

--- a/common/src/client/java/de/zannagh/armorhider/client/combat/ClientCombatManager.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/combat/ClientCombatManager.java
@@ -17,16 +17,22 @@ import java.util.function.Function;
 public final class ClientCombatManager {
     public static void handleCombat(Function<Player, Boolean> shouldLogCombat, DamageSource damageSource, @Nullable Player victim) {
         if (victim != null && shouldLogCombat.apply(victim)) {
-            CombatManager.logCombat(PlayerNameUtil.getPlayerName(victim));
-            if (Minecraft.getInstance().player != null) {
-                ClientPacketSender.sendToServer(new CombatLogEventPacket(victim, Minecraft.getInstance().player.getUUID()));
+            var victimName = PlayerNameUtil.getPlayerName(victim);
+            if (victimName != null) {
+                CombatManager.logCombat(victimName);
+                if (Minecraft.getInstance().player != null) {
+                    ClientPacketSender.sendToServer(new CombatLogEventPacket(victim, Minecraft.getInstance().player.getUUID()));
+                }
             }
         }
 
         if (damageSource.getEntity() instanceof AbstractClientPlayer attacker && shouldLogCombat.apply(attacker)) {
-            CombatManager.logCombat(PlayerNameUtil.getPlayerName(attacker));
-            if (Minecraft.getInstance().player != null) {
-                ClientPacketSender.sendToServer(new CombatLogEventPacket(attacker, Minecraft.getInstance().player.getUUID()));
+            var attackerName = PlayerNameUtil.getPlayerName(attacker);
+            if (attackerName != null) {
+                CombatManager.logCombat(attackerName);
+                if (Minecraft.getInstance().player != null) {
+                    ClientPacketSender.sendToServer(new CombatLogEventPacket(attacker, Minecraft.getInstance().player.getUUID()));
+                }
             }
         }
     }

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/LivingEntityRenderStateMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/LivingEntityRenderStateMixin.java
@@ -29,8 +29,8 @@ public class LivingEntityRenderStateMixin implements IdentityStateCarrier {
     private @Nullable IdentityCarrier armorHider$carrier;
 
     @Override
-    public @Nullable String playerName() {
-        return armorHider$carrier != null ? armorHider$carrier.playerName() : null;
+    public @Nullable String armorHider$playerName() {
+        return armorHider$carrier != null ? armorHider$carrier.armorHider$playerName() : null;
     }
 
     @Override

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/LivingEntityRendererMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/LivingEntityRendererMixin.java
@@ -120,7 +120,7 @@ public abstract class LivingEntityRendererMixin
             return;
         }
 
-        String name = carrier.playerName();
+        String name = carrier.armorHider$playerName();
         if (name == null) { 
             return;
         }
@@ -151,7 +151,7 @@ public abstract class LivingEntityRendererMixin
             return;
         }
 
-        String name = carrier.playerName();
+        String name = carrier.armorHider$playerName();
         if (name == null) {
             return;
         }

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/PlayerMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/PlayerMixin.java
@@ -12,6 +12,7 @@ import de.zannagh.armorhider.client.combat.ClientCombatManager;
 import de.zannagh.armorhider.client.scopes.ActiveModification;
 import de.zannagh.armorhider.client.scopes.IdentityCarrier;
 import de.zannagh.armorhider.log.DebugTracer;
+import de.zannagh.armorhider.util.PlayerNameUtil;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
@@ -42,8 +43,8 @@ public class PlayerMixin implements IdentityCarrier {
     }
     
     @Override
-    public @Nullable String playerName() {
-        return ((Player) (Object) this).getName().getString();
+    public @Nullable String armorHider$playerName() {
+        return PlayerNameUtil.getPlayerName(this);
     }
 
     @Override
@@ -83,8 +84,8 @@ public class PlayerMixin implements IdentityCarrier {
             return original;
         }
 
-        if (ActiveModification.isSlotFullyHidden(playerName(), slot, original)) {
-            DebugTracer.equipmentSlotHidingFired(playerName(), slot, true, "isSlotFullyHidden");
+        if (ActiveModification.isSlotFullyHidden(armorHider$playerName(), slot, original)) {
+            DebugTracer.equipmentSlotHidingFired(armorHider$playerName(), slot, true, "isSlotFullyHidden");
             return ItemStack.EMPTY;
         }
         return original;

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/HumanoidArmorLayerMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/HumanoidArmorLayerMixin.java
@@ -51,7 +51,7 @@ public class HumanoidArmorLayerMixin
     )
     private <S extends HumanoidRenderState> void captureRenderState(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, S humanoidRenderState, float f, float g, CallbackInfo ci) {
         if (humanoidRenderState instanceof IdentityCarrier carrier) {
-            ArmorHiderClient.RENDER_CONTEXT.setCurrentPlayer(carrier.playerName());
+            ArmorHiderClient.RENDER_CONTEXT.setCurrentPlayer(carrier.armorHider$playerName());
         }
     }
     *///?}
@@ -63,7 +63,7 @@ public class HumanoidArmorLayerMixin
     )
     private void capturePlayerName(PoseStack poseStack, MultiBufferSource bufferSource, int light, T entity, float f1, float f2, float f3, float f4, float f5, float f6, CallbackInfo ci) {
         if (entity instanceof IdentityCarrier carrier) {
-            ArmorHiderClient.RENDER_CONTEXT.setCurrentPlayer(carrier.playerName());
+            ArmorHiderClient.RENDER_CONTEXT.setCurrentPlayer(carrier.armorHider$playerName());
         }
     }
     *///?}

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/hand/ItemEntityRendererMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/hand/ItemEntityRendererMixin.java
@@ -39,11 +39,6 @@ public class ItemEntityRendererMixin {
         if (slot != EquipmentSlot.OFFHAND) {
             return;
         }
-        //? if >= 1.21.9
-        String name = player.getGameProfile().name();
-        //? if < 1.21.9
-        //String name = player.getGameProfile().getName();
-        
         carrier.createModification(slot, itemEntity.getItem());
     }
 

--- a/common/src/client/java/de/zannagh/armorhider/client/net/ClientCommunicationManager.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/net/ClientCommunicationManager.java
@@ -54,6 +54,12 @@ public final class ClientCommunicationManager {
         ClientConnectionEvents.registerJoin((handler, client) -> {
             assert client.player != null;
             var playerName = PlayerNameUtil.getPlayerName(client.player);
+            if (playerName == null || playerName.isBlank()) {
+                //? if >= 1.21.9
+                playerName = client.player.getGameProfile().name();
+                //? if < 1.21.9
+                /*playerName = client.player.getGameProfile().getName();*/
+            }
             ArmorHiderClient.CLIENT_CONFIG_MANAGER.updateName(playerName);
             //? if >= 1.21.9
             ArmorHiderClient.CLIENT_CONFIG_MANAGER.updateId(handler.getLocalGameProfile().id());

--- a/common/src/client/java/de/zannagh/armorhider/client/net/ClientCommunicationManager.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/net/ClientCommunicationManager.java
@@ -7,6 +7,7 @@ import de.zannagh.armorhider.log.DebugLogger;
 import de.zannagh.armorhider.net.packets.CombatLogNotificationPacket;
 import de.zannagh.armorhider.net.packets.PermissionPacket;
 import de.zannagh.armorhider.server.ServerConfiguration;
+import de.zannagh.armorhider.util.PlayerNameUtil;
 import net.minecraft.client.multiplayer.ServerData;
 
 //? if >= 1.20.5 
@@ -52,7 +53,7 @@ public final class ClientCommunicationManager {
 
         ClientConnectionEvents.registerJoin((handler, client) -> {
             assert client.player != null;
-            var playerName = client.player.getName().getString();
+            var playerName = PlayerNameUtil.getPlayerName(client.player);
             ArmorHiderClient.CLIENT_CONFIG_MANAGER.updateName(playerName);
             //? if >= 1.21.9
             ArmorHiderClient.CLIENT_CONFIG_MANAGER.updateId(handler.getLocalGameProfile().id());

--- a/common/src/client/java/de/zannagh/armorhider/client/scopes/IdentityCarrier.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/scopes/IdentityCarrier.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
  * for downstream render interceptors.
  */
 public interface IdentityCarrier {
-    @Nullable String playerName();
+    @Nullable String armorHider$playerName();
 
     @Nullable ItemStack customHeadItem();
 
@@ -30,7 +30,7 @@ public interface IdentityCarrier {
      */
     default @Nullable ActiveModification createModification(@NotNull EquipmentSlot slot, @Nullable ItemStack item) {
         
-        var mod = ActiveModification.create(playerName(), slot, item);
+        var mod = ActiveModification.create(armorHider$playerName(), slot, item);
         if (mod != null) {
             ArmorHiderClient.RENDER_CONTEXT.setActiveModification(mod);
         } else {

--- a/common/src/main/java/de/zannagh/armorhider/net/packets/CombatLogEventPacket.java
+++ b/common/src/main/java/de/zannagh/armorhider/net/packets/CombatLogEventPacket.java
@@ -2,6 +2,7 @@
 package de.zannagh.armorhider.net.packets;
 
 import de.zannagh.armorhider.net.CompressedJsonCodec;
+import de.zannagh.armorhider.util.PlayerNameUtil;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -25,7 +26,7 @@ public class CombatLogEventPacket implements CustomPacketPayload {
     public UUID originator;
 
     public CombatLogEventPacket(Player player, UUID originator) {
-        this.playerName = player.getDisplayName().getString();
+        this.playerName = PlayerNameUtil.getPlayerName(player);
         this.timestamp = System.currentTimeMillis();
         this.originator = originator;
     }
@@ -53,7 +54,7 @@ public class CombatLogEventPacket {
     public UUID originator;
 
     public CombatLogEventPacket(Player player, UUID originator) {
-        this.playerName = player.getDisplayName().getString();
+        this.playerName = PlayerNameUtil.getPlayerName(player);
         this.timestamp = System.currentTimeMillis();
         this.originator = originator;
     }

--- a/common/src/main/java/de/zannagh/armorhider/net/packets/CombatLogEventPacket.java
+++ b/common/src/main/java/de/zannagh/armorhider/net/packets/CombatLogEventPacket.java
@@ -41,6 +41,7 @@ public class CombatLogEventPacket implements CustomPacketPayload {
 //? if < 1.20.5 {
 /*package de.zannagh.armorhider.net.packets;
 
+import de.zannagh.armorhider.util.PlayerNameUtil;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.player.Player;
 import java.util.UUID;

--- a/common/src/main/java/de/zannagh/armorhider/net/packets/CombatLogNotificationPacket.java
+++ b/common/src/main/java/de/zannagh/armorhider/net/packets/CombatLogNotificationPacket.java
@@ -53,6 +53,7 @@ public class CombatLogNotificationPacket implements CustomPacketPayload {
 //? if < 1.20.5 {
 /*package de.zannagh.armorhider.net.packets;
 
+import de.zannagh.armorhider.util.PlayerNameUtil;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.player.Player;
 import java.util.UUID;

--- a/common/src/main/java/de/zannagh/armorhider/net/packets/CombatLogNotificationPacket.java
+++ b/common/src/main/java/de/zannagh/armorhider/net/packets/CombatLogNotificationPacket.java
@@ -2,6 +2,7 @@
 package de.zannagh.armorhider.net.packets;
 
 import de.zannagh.armorhider.net.CompressedJsonCodec;
+import de.zannagh.armorhider.util.PlayerNameUtil;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -37,7 +38,7 @@ public class CombatLogNotificationPacket implements CustomPacketPayload {
     }
 
     public CombatLogNotificationPacket(Player player, UUID originator) {
-        this.playerName = player.getDisplayName().getString();
+        this.playerName = PlayerNameUtil.getPlayerName(player);
         this.timestamp = System.currentTimeMillis();
         this.originator = originator;
     }
@@ -77,7 +78,7 @@ public class CombatLogNotificationPacket {
     }
 
     public CombatLogNotificationPacket(Player player, UUID originator) {
-        this.playerName = player.getDisplayName().getString();
+        this.playerName = PlayerNameUtil.getPlayerName(player);
         this.timestamp = System.currentTimeMillis();
         this.originator = originator;
     }

--- a/common/src/main/java/de/zannagh/armorhider/server/ServerConfiguration.java
+++ b/common/src/main/java/de/zannagh/armorhider/server/ServerConfiguration.java
@@ -8,6 +8,7 @@ import com.google.gson.reflect.TypeToken;
 import de.zannagh.armorhider.ArmorHider;
 import de.zannagh.armorhider.configuration.ConfigurationSource;
 import de.zannagh.armorhider.net.packets.ServerWideSettings;
+import de.zannagh.armorhider.util.PlayerNameUtil;
 
 import de.zannagh.armorhider.net.CompressedJsonCodec;
 import de.zannagh.armorhider.net.packets.PlayerConfig;
@@ -152,10 +153,11 @@ public class ServerConfiguration implements ConfigurationSource<ServerConfigurat
 
     public PlayerConfig getPlayerConfigOrDefault(Player player) {
         PlayerConfig uuidConfig = getPlayerConfigOrDefault(player.getUUID());
-        if (uuidConfig != null && Objects.equals(uuidConfig.playerName.getValue(), Objects.requireNonNull(player.getDisplayName()).getString())) {
+        String name = PlayerNameUtil.getPlayerName(player);
+        if (uuidConfig != null && Objects.equals(uuidConfig.playerName.getValue(), name)) {
             return uuidConfig;
         }
-        return getPlayerConfigOrDefault(Objects.requireNonNull(player.getDisplayName()).getString());
+        return getPlayerConfigOrDefault(name);
     }
 
     public PlayerConfig getPlayerConfigOrDefault(UUID uuid) {

--- a/common/src/main/java/de/zannagh/armorhider/util/PlayerNameUtil.java
+++ b/common/src/main/java/de/zannagh/armorhider/util/PlayerNameUtil.java
@@ -1,0 +1,27 @@
+package de.zannagh.armorhider.util;
+
+import net.minecraft.world.entity.player.Player;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Centralised player-name resolution. Every piece of code that extracts a
+ * human-readable name from a {@link Player} (or something that might be one)
+ * must go through this class so that the naming strategy is consistent
+ * across config look-ups, identity comparisons, and rendering.
+ */
+public final class PlayerNameUtil {
+
+    private PlayerNameUtil() {}
+
+    /**
+     * Returns the display name of a player entity, or {@code null} if
+     * {@code entity} is not a {@link Player} or yields an empty name.
+     */
+    public static @Nullable String getPlayerName(@Nullable Object entity) {
+        if (!(entity instanceof Player player)) {
+            return null;
+        }
+        String name = player.getDisplayName().getString();
+        return name.isEmpty() ? null : name;
+    }
+}

--- a/common/src/main/java/de/zannagh/armorhider/util/PlayerNameUtil.java
+++ b/common/src/main/java/de/zannagh/armorhider/util/PlayerNameUtil.java
@@ -22,6 +22,14 @@ public final class PlayerNameUtil {
             return null;
         }
         String name = player.getDisplayName().getString();
+        if (name.isEmpty()) {
+            //? if >= 1.21.9 {
+            name = player.getGameProfile().name();
+            //?}
+            //? if < 1.21.9 {
+            /*name = player.getGameProfile().getName();
+            *///?}
+        }
         return name.isEmpty() ? null : name;
     }
 }


### PR DESCRIPTION
Player names are now resolved in a common util method via displayName instead of using different approaches within the code base. The latter could cause the mod failing to resolve configurations when servers alter the display name (by name tags or such).

See #189 