### PR TITLE
fix: add explicit render pipeline compatibility for custom render types with iris (above 1.21.5)

### DIFF
--- a/buildSrc/src/main/kotlin/multiloader-loader.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-loader.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
     if (hasProperty("geckolib.version")) {
         add("compileOnly", "maven.modrinth:geckolib:${findProperty("geckolib.version")}")
     }
+    if (hasProperty("iris.version")) {
+        add("compileOnly", "maven.modrinth:iris:${findProperty("iris.version")}")
+    }
 }
 
 // Include common's sources in the loader's source sets for IntelliJ

--- a/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
@@ -77,6 +77,9 @@ if (branch == "common") {
         if (hasProperty("elytratrims.version")) {
             add(modDep, "maven.modrinth:elytra-trims:${findProperty("elytratrims.version")}")
         }
+        if (hasProperty("iris.version")) {
+            add(modClientDep, "maven.modrinth:iris:${findProperty("iris.version")}")
+        }
         add("compileOnly", "net.luckperms:api:5.4")
         add("compileOnly", "org.jspecify:jspecify:1.0.0")
         add("testImplementation", platform("org.junit:junit-bom:6.0.1"))

--- a/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
@@ -39,6 +39,7 @@ repositories {
 with(sc) {
     constants["fabric"] = current.project.contains("fabric")
     constants["neoforge"] = current.project.contains("neoforge")
+    constants["iris"] = hasProperty("iris.version")
 }
 
 // ── Common branch ──

--- a/common/src/client/java/de/zannagh/armorhider/client/ArmorHiderClient.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/ArmorHiderClient.java
@@ -50,13 +50,11 @@ public class ArmorHiderClient {
     public static void init() {
         ArmorHider.LOGGER.info("Armor Hider client initializing...");
         ClientCommunicationManager.initClient();
-        //? if >= 1.21.5
-        if (IRIS_LOADED) {
-            initIrisCompat();
-        }
+        //? if iris
+        if (IRIS_LOADED) initIrisCompat();
     }
 
-    //? if >= 1.21.5 {
+    //? if iris {
     private static void initIrisCompat() {
         try {
             de.zannagh.armorhider.client.compat.iris.IrisCompat.registerPipelines();

--- a/common/src/client/java/de/zannagh/armorhider/client/ArmorHiderClient.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/ArmorHiderClient.java
@@ -31,6 +31,7 @@ public class ArmorHiderClient {
     public static final boolean FA_LOADED = CompatFlags.FA_LOADED || classExists("net.kenddie.fantasyarmor.FantasyArmor");
     public static final boolean GECKOLIB_LOADED = CompatFlags.GECKOLIB_LOADED || classExists("software.bernie.geckolib.renderer.GeoArmorRenderer");
     public static boolean ET_LOADED = CompatFlags.ET_LOADED || classExists("dev.kikugie.elytratrims.ep.ETClientEntrypoint");
+    public static final boolean IRIS_LOADED = classExists("net.irisshaders.iris.api.v0.IrisApi");
 
     private static boolean classExists(String name) {
         try {
@@ -49,7 +50,21 @@ public class ArmorHiderClient {
     public static void init() {
         ArmorHider.LOGGER.info("Armor Hider client initializing...");
         ClientCommunicationManager.initClient();
+        //? if >= 1.21.5
+        if (IRIS_LOADED) {
+            initIrisCompat();
+        }
     }
+
+    //? if >= 1.21.5 {
+    private static void initIrisCompat() {
+        try {
+            de.zannagh.armorhider.client.compat.iris.IrisCompat.registerPipelines();
+        } catch (Exception e) {
+            ArmorHider.LOGGER.warn("Failed to register pipelines with Iris", e);
+        }
+    }
+    //?}
     
     public static @NonNull Boolean isClientConnectedToServer() {
         return Minecraft.getInstance().isLocalServer()

--- a/common/src/client/java/de/zannagh/armorhider/client/compat/iris/IrisCompat.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/compat/iris/IrisCompat.java
@@ -1,4 +1,4 @@
-//? if >= 1.21.5 {
+//? if iris {
 package de.zannagh.armorhider.client.compat.iris;
 
 import de.zannagh.armorhider.ArmorHider;

--- a/common/src/client/java/de/zannagh/armorhider/client/compat/iris/IrisCompat.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/compat/iris/IrisCompat.java
@@ -1,0 +1,26 @@
+//? if >= 1.21.5 {
+package de.zannagh.armorhider.client.compat.iris;
+
+import de.zannagh.armorhider.ArmorHider;
+import de.zannagh.armorhider.client.rendering.ArmorHiderRenderTypes;
+import net.irisshaders.iris.api.v0.IrisApi;
+import net.irisshaders.iris.api.v0.IrisProgram;
+
+public final class IrisCompat {
+
+    private IrisCompat() {}
+
+    public static void registerPipelines() {
+        var api = IrisApi.getInstance();
+        if (api.getMinorApiRevision() < 3) {
+            ArmorHider.LOGGER.warn("Iris API revision {} does not support pipeline registration, skipping",
+                    api.getMinorApiRevision());
+            return;
+        }
+        for (var pipeline : ArmorHiderRenderTypes.pipelines()) {
+            api.assignPipeline(pipeline, IrisProgram.ENTITIES_TRANSLUCENT);
+        }
+        ArmorHider.LOGGER.debug("Registered custom pipelines with Iris");
+    }
+}
+//?}

--- a/common/src/client/java/de/zannagh/armorhider/client/rendering/ArmorHiderRenderTypes.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/rendering/ArmorHiderRenderTypes.java
@@ -141,6 +141,16 @@ public final class ArmorHiderRenderTypes {
             Identifier.fromNamespaceAndPath("armor_hider", "pipeline/item_entity_translucent_cull_no_depth"));
     *///?}
 
+    //? if >= 1.21.5 {
+    public static RenderPipeline[] pipelines() {
+        return new RenderPipeline[] {
+            ARMOR_TRANSLUCENT_NO_DEPTH,
+            ENTITY_TRANSLUCENT_NO_DEPTH,
+            ITEM_ENTITY_TRANSLUCENT_CULL_NO_DEPTH
+        };
+    }
+    //?}
+
     // --- Render types ---
 
     //? if >= 1.21.11 {

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -113,18 +113,21 @@ geckolib.version = "HFSs3Co0"
 "fabric.minecraft_version_range" = ">=1.21.5 <=1.21.8"
 elytratrims.version = "QklJxw1S"
 geckolib.version = "k4Azk0wN"
+iris.version = "Rhzf61g1"
 
 ["fabric-1.21.10"]
 "fabric.minecraft_version" = "1.21.10"
 "fabric.minecraft_version_range" = ">=1.21.9 <=1.21.10"
 elytratrims.version = "iLC0LP3D"
 geckolib.version = "7qjQQSWv"
+iris.version = "a98UkgML"
 
 ["fabric-1.21.11"]
 "fabric.minecraft_version" = "1.21.11"
 "fabric.minecraft_version_range" = "1.21.11"
 elytratrims.version = "Nzd1iQCn"
 geckolib.version = "G1BvHQDL"
+iris.version = "fDpuVzVr"
 
 ["fabric-26.1-snapshot-11"]
 "fabric.minecraft_version" = "26.1-alpha.11"
@@ -156,6 +159,7 @@ geckolib.version = "yUpAp23B"
 loader_version = "0.18.4"
 elytratrims.version = "NLOF6eKu"
 geckolib.version = "yUpAp23B"
+iris.version = "MwcLS51S"
 
 ["fabric-26.2-snapshot-3"]
 "fabric.minecraft_version" = "26.2-alpha.3"
@@ -181,21 +185,25 @@ geckolib.version = "eQtABRub"
 "neoforge.minecraft_version_range" = "[1.21.5,1.21.8]"
 geckolib.version = "KPEgpbCC"
 elytratrims.version = "RMLnPwtS"
+iris.version = "Rhzf61g1"
 
 ["neoforge-1.21.10"]
 "neoforge.version" = "21.10.64"
 "neoforge.minecraft_version_range" = "[1.21.9,1.21.10]"
 geckolib.version = "xji1VqGU"
 elytratrims.version = "GxM8lsm4"
+iris.version = "a98UkgML"
 
 ["neoforge-1.21.11"]
 "neoforge.version" = "21.11.42"
 "neoforge.minecraft_version_range" = "[1.21.11]"
 geckolib.version = "FpONDAt3"
 elytratrims.version = "u2w6bgX3"
+iris.version = "fDpuVzVr"
 
 ["neoforge-26.1.2"]
 "neoforge.version" = "26.1.1.11-beta"
 "neoforge.minecraft_version_range" = "[26.1,26.1.2]"
 geckolib.version = "ScUAwGRA"
 elytratrims.version = "wgUBgHvL"
+iris.version = "MwcLS51S"


### PR DESCRIPTION
* adds render pipelines for AH's custom render types
* explicitly assigns the render pipelines to Iris for when their API allows it (1.21.5 and later)