### PR TITLE
feat: mekanism compatibility, closes #208

### DIFF
--- a/buildSrc/src/main/kotlin/multiloader-loader.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-loader.gradle.kts
@@ -36,6 +36,9 @@ dependencies {
     if (hasProperty("etf.version")) {
         add("compileOnly", "maven.modrinth:entitytexturefeatures:${findProperty("etf.version")}")
     }
+    if (hasProperty("mekanism.version")) {
+        add("compileOnly", "maven.modrinth:mekanism:${findProperty("mekanism.version")}")
+    }
 }
 
 // Include common's sources in the loader's source sets for IntelliJ

--- a/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
@@ -39,6 +39,7 @@ repositories {
 with(sc) {
     constants["fabric"] = current.project.contains("fabric")
     constants["neoforge"] = current.project.contains("neoforge")
+    constants["mekanism"] = hasProperty("mekanism.version")
 }
 
 // ── Common branch ──
@@ -85,6 +86,9 @@ if (branch == "common") {
         }
         if (hasProperty("etf.version")) {
             add(modClientDep, "maven.modrinth:entitytexturefeatures:${findProperty("etf.version")}")
+        }
+        if (hasProperty("mekanism.version")) {
+            add(modClientDep, "maven.modrinth:mekanism:${findProperty("mekanism.version")}")
         }
         add("compileOnly", "net.luckperms:api:5.4")
         add("compileOnly", "org.jspecify:jspecify:1.0.0")

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/mekanism/MekaSuitArmorMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/mekanism/MekaSuitArmorMixin.java
@@ -1,0 +1,25 @@
+//? if mekanism {
+/*package de.zannagh.armorhider.client.mixin.compat.mekanism;
+
+import de.zannagh.armorhider.client.ArmorHiderClient;
+import mekanism.client.render.armor.MekaSuitArmor;
+import mekanism.common.lib.Color;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Pseudo
+@Mixin(value = MekaSuitArmor.class, remap = false)
+public class MekaSuitArmorMixin {
+
+    @ModifyVariable(method = "renderMekaSuit", at = @At("HEAD"), ordinal = 0, argsOnly = true, require = 0)
+    private Color applyTransparencyToColor(Color color) {
+        var mod = ArmorHiderClient.RENDER_CONTEXT.activeModification();
+        if (mod != null && mod.transparency() < 1.0) {
+            return color.alpha(color.ad() * mod.transparency());
+        }
+        return color;
+    }
+}
+*///?}

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/mekanism/MekanismArmorMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/mekanism/MekanismArmorMixin.java
@@ -1,83 +1,24 @@
-//? if >= 1.21.9 {
-package de.zannagh.armorhider.client.mixin.compat.mekanism;
-
-import com.mojang.blaze3d.vertex.PoseStack;
-import de.zannagh.armorhider.client.ArmorHiderClient;
-import de.zannagh.armorhider.client.scopes.ActiveModification;
-import de.zannagh.armorhider.client.scopes.IdentityCarrier;
-import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
-import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.item.ItemStack;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Pseudo;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Coerce;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-@SuppressWarnings("UnresolvedMixinReference")
-@Pseudo
-@Mixin(targets = "mekanism.client.render.layer.MekanismArmorLayer", remap = false)
-public class MekanismArmorMixin {
-
-    @Inject(method = "renderArmorPart", at = @At("HEAD"), cancellable = true, require = 0)
-    private void interceptMekanismArmor(
-            PoseStack poseStack,
-            SubmitNodeCollector nodeCollector,
-            ItemStack stack,
-            EquipmentSlot slot,
-            @Coerce HumanoidRenderState state,
-            int lightCoords,
-            CallbackInfo ci) {
-        if (!(state instanceof IdentityCarrier carrier)
-                || !(carrier.createModification(slot, stack) instanceof ActiveModification mod)) {
-            return;
-        }
-
-        if (mod.shouldHide()) {
-            ArmorHiderClient.RENDER_CONTEXT.clearActiveModification();
-            ci.cancel();
-        }
-    }
-
-    @Inject(method = "renderArmorPart", at = @At("RETURN"), require = 0)
-    private void clearMekanismContext(
-            PoseStack poseStack,
-            SubmitNodeCollector nodeCollector,
-            ItemStack stack,
-            EquipmentSlot slot,
-            @Coerce HumanoidRenderState state,
-            int lightCoords,
-            CallbackInfo ci) {
-        ArmorHiderClient.RENDER_CONTEXT.clearActiveModification();
-    }
-}
-//?}
-
-//? if < 1.21.9 {
+//? if mekanism {
 /*package de.zannagh.armorhider.client.mixin.compat.mekanism;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import de.zannagh.armorhider.client.ArmorHiderClient;
-import de.zannagh.armorhider.client.scopes.ActiveModification;
+import de.zannagh.armorhider.client.rendering.MekanismRenderCompat;
 import de.zannagh.armorhider.client.scopes.IdentityCarrier;
+import mekanism.client.render.layer.MekanismArmorLayer;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-//? if < 1.21.5 {
-/^import de.zannagh.armorhider.client.rendering.MekanismRenderCompat;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
-^///?}
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@SuppressWarnings("UnresolvedMixinReference")
 @Pseudo
-@Mixin(targets = "mekanism.client.render.layer.MekanismArmorLayer", remap = false)
+@Mixin(value = MekanismArmorLayer.class, remap = false)
 public class MekanismArmorMixin {
 
     @Inject(method = "renderArmorPart", at = @At("HEAD"), cancellable = true, require = 0)
@@ -93,14 +34,20 @@ public class MekanismArmorMixin {
             return;
         }
         var mod = carrier.createModification(slot, entity.getItemBySlot(slot));
+        
+        if (mod != null && mod.transparency() < 1.0) {
+            @SuppressWarnings("unchecked")
+            var parentModel = ((RenderLayer<LivingEntity, ?>) (Object) this).getParentModel();
+            MekanismRenderCompat.renderBodyUnderArmor(parentModel, poseStack, bufferSource, entity, slot, light);
+        }
+        
         if (mod != null && mod.shouldHide()) {
             ArmorHiderClient.RENDER_CONTEXT.clearActiveModification();
             ci.cancel();
         }
     }
 
-    //? if < 1.21.5 {
-    /^@ModifyArg(
+    @ModifyArg(
             method = "renderArmorPart",
             at = @At(value = "INVOKE",
                     target = "Lmekanism/client/render/armor/ICustomArmor;render(Lnet/minecraft/client/model/HumanoidModel;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;IIFZLnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/ItemStack;)V"),
@@ -113,7 +60,6 @@ public class MekanismArmorMixin {
         }
         return original;
     }
-    ^///?}
 
     @Inject(method = "renderArmorPart", at = @At("RETURN"), require = 0)
     private <T extends LivingEntity> void clearMekanismContext(
@@ -124,12 +70,6 @@ public class MekanismArmorMixin {
             int light,
             float partialTicks,
             CallbackInfo ci) {
-        //? if < 1.21.5 {
-        /^var mod = ArmorHiderClient.RENDER_CONTEXT.activeModification();
-        if (mod != null && mod.transparency() < 1.0) {
-            MekanismRenderCompat.flushTranslucentBatch(bufferSource, (float) mod.transparency());
-        }
-        ^///?}
         ArmorHiderClient.RENDER_CONTEXT.clearActiveModification();
     }
 }

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/mekanism/MekanismArmorMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/mekanism/MekanismArmorMixin.java
@@ -1,0 +1,136 @@
+//? if >= 1.21.9 {
+package de.zannagh.armorhider.client.mixin.compat.mekanism;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import de.zannagh.armorhider.client.ArmorHiderClient;
+import de.zannagh.armorhider.client.scopes.ActiveModification;
+import de.zannagh.armorhider.client.scopes.IdentityCarrier;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@SuppressWarnings("UnresolvedMixinReference")
+@Pseudo
+@Mixin(targets = "mekanism.client.render.layer.MekanismArmorLayer", remap = false)
+public class MekanismArmorMixin {
+
+    @Inject(method = "renderArmorPart", at = @At("HEAD"), cancellable = true, require = 0)
+    private void interceptMekanismArmor(
+            PoseStack poseStack,
+            SubmitNodeCollector nodeCollector,
+            ItemStack stack,
+            EquipmentSlot slot,
+            @Coerce HumanoidRenderState state,
+            int lightCoords,
+            CallbackInfo ci) {
+        if (!(state instanceof IdentityCarrier carrier)
+                || !(carrier.createModification(slot, stack) instanceof ActiveModification mod)) {
+            return;
+        }
+
+        if (mod.shouldHide()) {
+            ArmorHiderClient.RENDER_CONTEXT.clearActiveModification();
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "renderArmorPart", at = @At("RETURN"), require = 0)
+    private void clearMekanismContext(
+            PoseStack poseStack,
+            SubmitNodeCollector nodeCollector,
+            ItemStack stack,
+            EquipmentSlot slot,
+            @Coerce HumanoidRenderState state,
+            int lightCoords,
+            CallbackInfo ci) {
+        ArmorHiderClient.RENDER_CONTEXT.clearActiveModification();
+    }
+}
+//?}
+
+//? if < 1.21.9 {
+/*package de.zannagh.armorhider.client.mixin.compat.mekanism;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import de.zannagh.armorhider.client.ArmorHiderClient;
+import de.zannagh.armorhider.client.scopes.ActiveModification;
+import de.zannagh.armorhider.client.scopes.IdentityCarrier;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+//? if < 1.21.5 {
+/^import de.zannagh.armorhider.client.rendering.MekanismRenderCompat;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+^///?}
+
+@SuppressWarnings("UnresolvedMixinReference")
+@Pseudo
+@Mixin(targets = "mekanism.client.render.layer.MekanismArmorLayer", remap = false)
+public class MekanismArmorMixin {
+
+    @Inject(method = "renderArmorPart", at = @At("HEAD"), cancellable = true, require = 0)
+    private <T extends LivingEntity> void interceptMekanismArmor(
+            PoseStack poseStack,
+            MultiBufferSource bufferSource,
+            T entity,
+            EquipmentSlot slot,
+            int light,
+            float partialTicks,
+            CallbackInfo ci) {
+        if (!(entity instanceof IdentityCarrier carrier)) {
+            return;
+        }
+        var mod = carrier.createModification(slot, entity.getItemBySlot(slot));
+        if (mod != null && mod.shouldHide()) {
+            ArmorHiderClient.RENDER_CONTEXT.clearActiveModification();
+            ci.cancel();
+        }
+    }
+
+    //? if < 1.21.5 {
+    /^@ModifyArg(
+            method = "renderArmorPart",
+            at = @At(value = "INVOKE",
+                    target = "Lmekanism/client/render/armor/ICustomArmor;render(Lnet/minecraft/client/model/HumanoidModel;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;IIFZLnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/ItemStack;)V"),
+            index = 2,
+            require = 0)
+    private MultiBufferSource wrapBufferForTransparency(MultiBufferSource original) {
+        var mod = ArmorHiderClient.RENDER_CONTEXT.activeModification();
+        if (mod != null && mod.transparency() < 1.0) {
+            return MekanismRenderCompat.wrapForTransparency(original);
+        }
+        return original;
+    }
+    ^///?}
+
+    @Inject(method = "renderArmorPart", at = @At("RETURN"), require = 0)
+    private <T extends LivingEntity> void clearMekanismContext(
+            PoseStack poseStack,
+            MultiBufferSource bufferSource,
+            T entity,
+            EquipmentSlot slot,
+            int light,
+            float partialTicks,
+            CallbackInfo ci) {
+        //? if < 1.21.5 {
+        /^var mod = ArmorHiderClient.RENDER_CONTEXT.activeModification();
+        if (mod != null && mod.transparency() < 1.0) {
+            MekanismRenderCompat.flushTranslucentBatch(bufferSource, (float) mod.transparency());
+        }
+        ^///?}
+        ArmorHiderClient.RENDER_CONTEXT.clearActiveModification();
+    }
+}
+*///?}

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/waveycapes/WaveyCapesMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/waveycapes/WaveyCapesMixin.java
@@ -33,7 +33,6 @@ import net.minecraft.client.renderer.entity.state.AvatarRenderState;
 @Pseudo
 @Mixin(targets = "dev.tr7zw.waveycapes.renderlayers.CustomCapeRenderLayer", remap = false)
 public class WaveyCapesMixin {
-
     @Unique
     //? if >= 1.21.9
     private static final String CAPE_METHOD = "submit";

--- a/common/src/client/java/de/zannagh/armorhider/client/rendering/MekanismRenderCompat.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/rendering/MekanismRenderCompat.java
@@ -1,82 +1,121 @@
-//? if < 1.21.5 {
+//? if mekanism {
 /*package de.zannagh.armorhider.client.rendering;
 
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
+import mekanism.client.render.MekanismRenderType;
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.model.player.PlayerModel;
+import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
 
-import java.lang.reflect.Field;
-
-public final class MekanismRenderCompat extends RenderStateShard {
-
-    private MekanismRenderCompat() {
-        super("armor_hider_mek_compat", () -> {}, () -> {});
-    }
+public final class MekanismRenderCompat {
 
     private static RenderType MEKASUIT_ORIGINAL;
-    private static RenderType MEKASUIT_TRANSLUCENT;
     private static boolean initialized;
 
     private static synchronized void init() {
         if (initialized) return;
         initialized = true;
-        try {
-            Field mekasuitField = Class.forName("mekanism.client.render.MekanismRenderType")
-                    .getDeclaredField("MEKASUIT");
-            mekasuitField.setAccessible(true);
-            MEKASUIT_ORIGINAL = (RenderType) mekasuitField.get(null);
-
-            Field trackerField = Class.forName("mekanism.client.render.MekanismShaders")
-                    .getDeclaredField("MEKASUIT");
-            trackerField.setAccessible(true);
-            Object tracker = trackerField.get(null);
-            Field shardField = tracker.getClass().getDeclaredField("shard");
-            shardField.setAccessible(true);
-            ShaderStateShard shaderShard = (ShaderStateShard) shardField.get(tracker);
-
-            MEKASUIT_TRANSLUCENT = RenderType.create(
-                    "armor_hider_mekasuit_translucent",
-                    DefaultVertexFormat.NEW_ENTITY,
-                    VertexFormat.Mode.QUADS,
-                    131_072, true, true,
-                    RenderType.CompositeState.builder()
-                            .setShaderState(shaderShard)
-                            .setTextureState(BLOCK_SHEET)
-                            .setLightmapState(LIGHTMAP)
-                            .setOverlayState(OVERLAY)
-                            .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
-                            .setWriteMaskState(COLOR_WRITE)
-                            .createCompositeState(true)
-            );
-        } catch (ReflectiveOperationException ignored) {
-        }
+        MEKASUIT_ORIGINAL = MekanismRenderType.MEKASUIT;
     }
 
     public static MultiBufferSource wrapForTransparency(MultiBufferSource original) {
         init();
-        if (MEKASUIT_ORIGINAL == null || MEKASUIT_TRANSLUCENT == null) {
+        if (MEKASUIT_ORIGINAL == null) {
             return original;
         }
-        RenderType opaqueType = MEKASUIT_ORIGINAL;
-        RenderType translucentType = MEKASUIT_TRANSLUCENT;
+        RenderType translucentType = RenderType.entityTranslucent(TextureAtlas.LOCATION_BLOCKS);
         return (RenderType type) -> {
-            if (type == opaqueType) {
+            if (type == MEKASUIT_ORIGINAL) {
                 return original.getBuffer(translucentType);
             }
             return original.getBuffer(type);
         };
     }
 
-    public static void flushTranslucentBatch(MultiBufferSource bufferSource, float alpha) {
-        init();
-        if (MEKASUIT_TRANSLUCENT == null) return;
-        if (!(bufferSource instanceof MultiBufferSource.BufferSource bs)) return;
-        RenderSystem.setShaderColor(1f, 1f, 1f, alpha);
-        bs.endBatch(MEKASUIT_TRANSLUCENT);
-        RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+    @SuppressWarnings("unchecked")
+    public static <T extends LivingEntity> void renderBodyUnderArmor(
+            EntityModel<?> parentModel,
+            PoseStack poseStack,
+            MultiBufferSource bufferSource,
+            T entity,
+            EquipmentSlot slot,
+            int light) {
+        if (!(entity instanceof AbstractClientPlayer player)
+            || !(parentModel instanceof PlayerModel<?> model)) {
+            return;
+        }
+        var skin = player.getSkin().texture();
+        var vc = bufferSource.getBuffer(RenderType.entityCutoutNoCull(skin));
+
+        boolean headVis = model.head.visible;
+        boolean hatVis = model.hat.visible;
+        boolean bodyVis = model.body.visible;
+        boolean leftArmVis = model.leftArm.visible;
+        boolean rightArmVis = model.rightArm.visible;
+        boolean leftLegVis = model.leftLeg.visible;
+        boolean rightLegVis = model.rightLeg.visible;
+        boolean jacketVis = model.jacket.visible;
+        boolean leftSleeveVis = model.leftSleeve.visible;
+        boolean rightSleeveVis = model.rightSleeve.visible;
+        boolean leftPantsVis = model.leftPants.visible;
+        boolean rightPantsVis = model.rightPants.visible;
+
+        model.setAllVisible(false);
+
+        boolean changeVisibility = true;
+        switch (slot) {
+            case HEAD -> {
+                model.head.visible = true;
+                model.hat.visible = true;
+            }
+            case CHEST -> {
+                model.body.visible = true;
+                model.leftArm.visible = true;
+                model.rightArm.visible = true;
+                model.jacket.visible = true;
+                model.leftSleeve.visible = true;
+                model.rightSleeve.visible = true;
+            }
+            case LEGS, FEET -> {
+                model.leftLeg.visible = true;
+                model.rightLeg.visible = true;
+                model.leftPants.visible = true;
+                model.rightPants.visible = true;
+            }
+            default -> {
+                changeVisibility = false;
+            }
+        }
+        
+        if (!changeVisibility) {
+            return;
+        }
+
+        poseStack.pushPose();
+        if (slot == EquipmentSlot.CHEST) {
+            poseStack.scale(0.99f, 0.99f, 0.99f); // Slightly shrink chest to prevent overlap-flickers.
+        }
+        model.renderToBuffer(poseStack, vc, light, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
+        poseStack.popPose();
+
+        model.head.visible = headVis;
+        model.hat.visible = hatVis;
+        model.body.visible = bodyVis;
+        model.leftArm.visible = leftArmVis;
+        model.rightArm.visible = rightArmVis;
+        model.leftLeg.visible = leftLegVis;
+        model.rightLeg.visible = rightLegVis;
+        model.jacket.visible = jacketVis;
+        model.leftSleeve.visible = leftSleeveVis;
+        model.rightSleeve.visible = rightSleeveVis;
+        model.leftPants.visible = leftPantsVis;
+        model.rightPants.visible = rightPantsVis;
     }
 }
 *///?}

--- a/common/src/client/java/de/zannagh/armorhider/client/rendering/MekanismRenderCompat.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/rendering/MekanismRenderCompat.java
@@ -1,0 +1,82 @@
+//? if < 1.21.5 {
+/*package de.zannagh.armorhider.client.rendering;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderStateShard;
+import net.minecraft.client.renderer.rendertype.RenderType;
+
+import java.lang.reflect.Field;
+
+public final class MekanismRenderCompat extends RenderStateShard {
+
+    private MekanismRenderCompat() {
+        super("armor_hider_mek_compat", () -> {}, () -> {});
+    }
+
+    private static RenderType MEKASUIT_ORIGINAL;
+    private static RenderType MEKASUIT_TRANSLUCENT;
+    private static boolean initialized;
+
+    private static synchronized void init() {
+        if (initialized) return;
+        initialized = true;
+        try {
+            Field mekasuitField = Class.forName("mekanism.client.render.MekanismRenderType")
+                    .getDeclaredField("MEKASUIT");
+            mekasuitField.setAccessible(true);
+            MEKASUIT_ORIGINAL = (RenderType) mekasuitField.get(null);
+
+            Field trackerField = Class.forName("mekanism.client.render.MekanismShaders")
+                    .getDeclaredField("MEKASUIT");
+            trackerField.setAccessible(true);
+            Object tracker = trackerField.get(null);
+            Field shardField = tracker.getClass().getDeclaredField("shard");
+            shardField.setAccessible(true);
+            ShaderStateShard shaderShard = (ShaderStateShard) shardField.get(tracker);
+
+            MEKASUIT_TRANSLUCENT = RenderType.create(
+                    "armor_hider_mekasuit_translucent",
+                    DefaultVertexFormat.NEW_ENTITY,
+                    VertexFormat.Mode.QUADS,
+                    131_072, true, true,
+                    RenderType.CompositeState.builder()
+                            .setShaderState(shaderShard)
+                            .setTextureState(BLOCK_SHEET)
+                            .setLightmapState(LIGHTMAP)
+                            .setOverlayState(OVERLAY)
+                            .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                            .setWriteMaskState(COLOR_WRITE)
+                            .createCompositeState(true)
+            );
+        } catch (ReflectiveOperationException ignored) {
+        }
+    }
+
+    public static MultiBufferSource wrapForTransparency(MultiBufferSource original) {
+        init();
+        if (MEKASUIT_ORIGINAL == null || MEKASUIT_TRANSLUCENT == null) {
+            return original;
+        }
+        RenderType opaqueType = MEKASUIT_ORIGINAL;
+        RenderType translucentType = MEKASUIT_TRANSLUCENT;
+        return (RenderType type) -> {
+            if (type == opaqueType) {
+                return original.getBuffer(translucentType);
+            }
+            return original.getBuffer(type);
+        };
+    }
+
+    public static void flushTranslucentBatch(MultiBufferSource bufferSource, float alpha) {
+        init();
+        if (MEKASUIT_TRANSLUCENT == null) return;
+        if (!(bufferSource instanceof MultiBufferSource.BufferSource bs)) return;
+        RenderSystem.setShaderColor(1f, 1f, 1f, alpha);
+        bs.endBatch(MEKASUIT_TRANSLUCENT);
+        RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+    }
+}
+*///?}

--- a/fabric/src/client/java/de/zannagh/armorhider/client/MixinPlugin.java
+++ b/fabric/src/client/java/de/zannagh/armorhider/client/MixinPlugin.java
@@ -52,7 +52,8 @@ public class MixinPlugin implements IMixinConfigPlugin {
             // Compat — @Pseudo, auto-skipped if target mod absent
             "compat.wildfiregender.GenderArmorLayerMixin",
             "compat.geckolib.GeckoLibArmorMixin",
-            "compat.waveycapes.WaveyCapesMixin"
+            "compat.waveycapes.WaveyCapesMixin",
+            "compat.mekanism.MekanismArmorMixin"
     };
 
     @Override

--- a/fabric/src/client/java/de/zannagh/armorhider/client/MixinPlugin.java
+++ b/fabric/src/client/java/de/zannagh/armorhider/client/MixinPlugin.java
@@ -54,6 +54,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
             "compat.wildfiregender.GenderArmorLayerMixin",
             "compat.geckolib.GeckoLibArmorMixin",
             "compat.waveycapes.WaveyCapesMixin",
+            "compat.mekanism.MekanismArmorMixin",
             "compat.emf.EmfModelPartMixin",
             "compat.emf.EmfModelPartRootMixin"
     };

--- a/fabric/src/client/java/de/zannagh/armorhider/client/MixinPlugin.java
+++ b/fabric/src/client/java/de/zannagh/armorhider/client/MixinPlugin.java
@@ -54,7 +54,6 @@ public class MixinPlugin implements IMixinConfigPlugin {
             "compat.wildfiregender.GenderArmorLayerMixin",
             "compat.geckolib.GeckoLibArmorMixin",
             "compat.waveycapes.WaveyCapesMixin",
-            "compat.mekanism.MekanismArmorMixin",
             "compat.emf.EmfModelPartMixin",
             "compat.emf.EmfModelPartRootMixin"
     };

--- a/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
+++ b/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
@@ -56,7 +56,9 @@ public class MixinPlugin implements IMixinConfigPlugin {
             "compat.wildfiregender.GenderArmorLayerMixin",
             "compat.geckolib.GeckoLibArmorMixin",
             "compat.waveycapes.WaveyCapesMixin",
+            // Compat - Pseudo and guarded in source for mekanism constant only (1.21.1 Neo)
             "compat.mekanism.MekanismArmorMixin",
+            "compat.mekanism.MekaSuitArmorMixin",
             "compat.emf.EmfModelPartMixin",
             "compat.emf.EmfModelPartRootMixin"
     };
@@ -73,15 +75,15 @@ public class MixinPlugin implements IMixinConfigPlugin {
     @Override
     public List<String> getMixins() {
         //? if >= 1.21.9 {
-        if (FMLEnvironment.getDist() == Dist.DEDICATED_SERVER) {
+        /*if (FMLEnvironment.getDist() == Dist.DEDICATED_SERVER) {
             return List.of();
         }
-        //?} else {
-        /*
+        *///?} else {
+        
         if (FMLEnvironment.dist == Dist.DEDICATED_SERVER) { 
             return List.of();
         }
-        *///?}
+        //?}
         var mixinsToAdd = new ArrayList<>(List.of(MIXINS));
         return MixinUtil.getMixinClassesWherePresent(PACKAGE, mixinsToAdd);
     }

--- a/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
+++ b/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
@@ -56,6 +56,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
             "compat.wildfiregender.GenderArmorLayerMixin",
             "compat.geckolib.GeckoLibArmorMixin",
             "compat.waveycapes.WaveyCapesMixin",
+            "compat.mekanism.MekanismArmorMixin",
             "compat.emf.EmfModelPartMixin",
             "compat.emf.EmfModelPartRootMixin"
     };

--- a/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
+++ b/neoforge/src/main/java/de/zannagh/armorhider/client/MixinPlugin.java
@@ -54,7 +54,8 @@ public class MixinPlugin implements IMixinConfigPlugin {
             // Compat — @Pseudo, auto-skipped if target mod absent
             "compat.wildfiregender.GenderArmorLayerMixin",
             "compat.geckolib.GeckoLibArmorMixin",
-            "compat.waveycapes.WaveyCapesMixin"
+            "compat.waveycapes.WaveyCapesMixin",
+            "compat.mekanism.MekanismArmorMixin"
     };
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {

--- a/neoforge/src/main/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/NeoForgeArmorColorMixin.java
+++ b/neoforge/src/main/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/NeoForgeArmorColorMixin.java
@@ -1,5 +1,5 @@
 //? if >= 1.21.9 {
-package de.zannagh.armorhider.client.mixin.bodyKneesAndToes;
+/*package de.zannagh.armorhider.client.mixin.bodyKneesAndToes;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -14,21 +14,21 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 //? if >= 1.21.11 {
-import net.minecraft.client.renderer.rendertype.RenderType;
-import net.minecraft.client.renderer.rendertype.RenderTypes;
-//? }
+/^import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.RenderTypes;
+^///? }
 
 //? if 1.21.9 || 1.21.10
 //import net.minecraft.client.renderer.RenderType;
 
-/**
+/^*
  * NeoForge-specific armor color transparency mixin.
  * <p>
  * On Fabric, armor color is modified upstream via {@code getColorForLayer} in renderLayers.
  * NeoForge patches renderLayers and never invokes {@code getColorForLayer}, so we handle
  * armor transparency at the SubmitNodeCollection level instead — the same approach used
  * for offhand items in {@code SubmitNodeCollectorMixin}.
- */
+ ^/
 @SuppressWarnings({"unused", "UnusedMixin"})
 @Mixin(SubmitNodeCollection.class)
 public class NeoForgeArmorColorMixin {
@@ -38,13 +38,13 @@ public class NeoForgeArmorColorMixin {
             at = @At(
                     value = "INVOKE",
                     //? if >= 1.21.11
-                    target = "Lnet/minecraft/client/renderer/feature/ModelPartFeatureRenderer$Storage;add(Lnet/minecraft/client/renderer/rendertype/RenderType;Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelPartSubmit;)V"
+                    //target = "Lnet/minecraft/client/renderer/feature/ModelPartFeatureRenderer$Storage;add(Lnet/minecraft/client/renderer/rendertype/RenderType;Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelPartSubmit;)V"
                     //? if 1.21.9 || 1.21.10
                     //target = "Lnet/minecraft/client/renderer/feature/ModelPartFeatureRenderer$Storage;add(Lnet/minecraft/client/renderer/RenderType;Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelPartSubmit;)V"
             )
     )
     //? if >= 1.21.11
-    private void wrapArmorModelPartAdd(ModelPartFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelPartSubmit submit, Operation<Void> original) {
+    //private void wrapArmorModelPartAdd(ModelPartFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelPartSubmit submit, Operation<Void> original) {
     //? if 1.21.9 || 1.21.10
     //private void wrapArmorModelPartAdd(ModelPartFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelPartSubmit submit, Operation<Void> original) {
         if (shouldApplyArmorTransparency()) {
@@ -66,7 +66,7 @@ public class NeoForgeArmorColorMixin {
             RenderType translucentType = renderType;
             if (submit.sprite() != null) {
                 //? if >= 1.21.11
-                translucentType = RenderTypes.entityTranslucent(submit.sprite().atlasLocation());
+                //translucentType = RenderTypes.entityTranslucent(submit.sprite().atlasLocation());
                 //? if 1.21.9 || 1.21.10
                 //translucentType = RenderType.entityTranslucent(submit.sprite().atlasLocation());
             }
@@ -82,13 +82,13 @@ public class NeoForgeArmorColorMixin {
             at = @At(
                     value = "INVOKE",
                     //? if >= 1.21.11
-                    target = "Lnet/minecraft/client/renderer/feature/ModelFeatureRenderer$Storage;add(Lnet/minecraft/client/renderer/rendertype/RenderType;Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelSubmit;)V"
+                    //target = "Lnet/minecraft/client/renderer/feature/ModelFeatureRenderer$Storage;add(Lnet/minecraft/client/renderer/rendertype/RenderType;Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelSubmit;)V"
                     //? if 1.21.9 || 1.21.10
                     //target = "Lnet/minecraft/client/renderer/feature/ModelFeatureRenderer$Storage;add(Lnet/minecraft/client/renderer/RenderType;Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelSubmit;)V"
             )
     )
     //? if >= 1.21.11
-    private <S> void wrapArmorModelAdd(ModelFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelSubmit<S> submit, Operation<Void> original) {
+    //private <S> void wrapArmorModelAdd(ModelFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelSubmit<S> submit, Operation<Void> original) {
     //? if 1.21.9 || 1.21.10
     //private <S> void wrapArmorModelAdd(ModelFeatureRenderer.Storage storage, RenderType renderType, SubmitNodeStorage.ModelSubmit<S> submit, Operation<Void> original) {
         if (shouldApplyArmorTransparency()) {
@@ -109,7 +109,7 @@ public class NeoForgeArmorColorMixin {
             RenderType translucentType = renderType;
             if (submit.sprite() != null) {
                 //? if >= 1.21.11
-                translucentType = RenderTypes.entityTranslucent(submit.sprite().atlasLocation());
+                //translucentType = RenderTypes.entityTranslucent(submit.sprite().atlasLocation());
                 //? if 1.21.9 || 1.21.10
                 //translucentType = RenderType.entityTranslucent(submit.sprite().atlasLocation());
             }
@@ -126,4 +126,4 @@ public class NeoForgeArmorColorMixin {
         return mod != null && mod.slot() != EquipmentSlot.OFFHAND;
     }
 }
-//?}
+*///?}

--- a/neoforge/src/main/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/NeoForgeHumanoidArmorLayerMixin.java
+++ b/neoforge/src/main/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/NeoForgeHumanoidArmorLayerMixin.java
@@ -1,5 +1,5 @@
 //? if >= 1.21 && < 1.21.4 {
-/*package de.zannagh.armorhider.client.mixin.bodyKneesAndToes;
+package de.zannagh.armorhider.client.mixin.bodyKneesAndToes;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -127,4 +127,4 @@ public class NeoForgeHumanoidArmorLayerMixin<T extends LivingEntity, M extends H
         model.renderToBuffer(poseStack, vertexConsumer, packedLight, packedOverlay, modifiedColor);
     }
 }
-*///?}
+//?}

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -209,6 +209,7 @@ elytratrims.version = "7mqA6CJO"
 iris.version = "t3ruzodq"
 emf.version = "PAYgk63v"
 etf.version = "YEMROAHv"
+mekanism.version = "5KzzycBT"
 
 ["neoforge-1.21.4"]
 "neoforge.version" = "21.4.156"


### PR DESCRIPTION
* adds compatibility for mekanism neoforge 1.21.1 (we don't target neo 1.20.1, so nothing else needed right now)
* supports full hide/show and transparency (redrawing the player model if necessary)
* should work with other mekanism armors outside of the MekaSuit due to changing MekanismArmorLayer rendering and not only MekaSuit