### PR TITLE
fix: pass initial config values correctly to layered buttons, fixes #250

### DIFF
--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/LayeredButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/LayeredButton.java
@@ -11,8 +11,8 @@ import org.jetbrains.annotations.Nullable;
 import net.minecraft.client.renderer.RenderPipelines;
 
 public abstract class LayeredButton extends Button {
-    protected boolean isEnabled = true;
 
+    protected boolean isEnabled;
     @Nullable protected Identifier midLayerSprite(boolean enabled) { return null; }
 
     protected Identifier spriteBg() {
@@ -29,10 +29,11 @@ public abstract class LayeredButton extends Button {
     //? if < 1.21
     //protected static Identifier modSprite(String name) { return new Identifier("armor-hider", name); }
 
-    public LayeredButton(int width, int height, Component message, OnPress onPress) {
+    public LayeredButton(boolean initial, int width, int height, Component message, OnPress onPress) {
         super(0, 0, width, height, message, onPress, (discarded) -> MutableComponent.create(message.getContents()));
         this.setMessage(message);
         this.setTooltip(Tooltip.create(message));
+        this.isEnabled = initial;
     }
 
     protected abstract Component enabledMessage();

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/LayeredImageButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/LayeredImageButton.java
@@ -14,8 +14,8 @@ public abstract class LayeredImageButton extends LayeredButton {
 
     @Nullable protected final EquipmentSlot slot;
 
-    public LayeredImageButton(@Nullable EquipmentSlot slot, int width, int height, Component message, OnPress onPress) {
-        super(width, height, message, onPress);
+    public LayeredImageButton(@Nullable EquipmentSlot slot, boolean initial, int width, int height, Component message, OnPress onPress) {
+        super(initial, width, height, message, onPress);
         this.slot = slot;
     }
 

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/SquareLayeredTextButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/SquareLayeredTextButton.java
@@ -8,8 +8,8 @@ public abstract class SquareLayeredTextButton extends LayeredButton {
 
     private final String label;
 
-    public SquareLayeredTextButton(String label, Component message, OnPress onPress) {
-        super(UiConstants.SQUARE_BUTTON_WIDTH, UiConstants.DEFAULT_BUTTON_HEIGHT, message, onPress);
+    public SquareLayeredTextButton(boolean initial, String label, Component message, OnPress onPress) {
+        super(initial, UiConstants.SQUARE_BUTTON_WIDTH, UiConstants.DEFAULT_BUTTON_HEIGHT, message, onPress);
         this.label = label;
     }
 

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/AffectOtherItemsButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/AffectOtherItemsButton.java
@@ -53,7 +53,7 @@ public class AffectOtherItemsButton extends LayeredImageButton {
     }
 
     public AffectOtherItemsButton(boolean initial, EquipmentSlot slot, int width, int height, OnPress onPress) {
-        super(slot, width, height, initial ? enabledMsg(slot) : disabledMsg(slot), onPress);
+        super(slot, initial, width, height, initial ? enabledMsg(slot) : disabledMsg(slot), onPress);
         if (slot == EquipmentSlot.HEAD) {
             slotSprite = modSprite("affect_head_slot_button");
         }

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/CombatDetectionButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/CombatDetectionButton.java
@@ -12,7 +12,7 @@ public class CombatDetectionButton extends LayeredImageButton {
     private final Identifier disabledSlotSprite = modSprite("in_combat_button_icon_disabled");
 
     public CombatDetectionButton(boolean initial, OnPress onPress) {
-        super(null, UiConstants.SQUARE_BUTTON_WIDTH, UiConstants.DEFAULT_BUTTON_HEIGHT,
+        super(null, initial, UiConstants.SQUARE_BUTTON_WIDTH, UiConstants.DEFAULT_BUTTON_HEIGHT,
                 initial ? CombatDetectionButton.enabledMsg() : CombatDetectionButton.disabledMsg(), onPress);
     }
 

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/ExtendedSlotIconButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/ExtendedSlotIconButton.java
@@ -13,7 +13,7 @@ public class ExtendedSlotIconButton extends LayeredImageButton {
     
 
     public ExtendedSlotIconButton(EquipmentSlot slot, int width, int height, OnPress onPress) {
-        super(slot, width, height, buttonMessage, onPress);
+        super(slot, true, width, height, buttonMessage, onPress);
     }
 
     private static final Component buttonMessage = Component.translatable("armorhider.options.item_exclusion.button_tooltip");

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/GlintSlotOnOffButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/GlintSlotOnOffButton.java
@@ -64,7 +64,7 @@ public class GlintSlotOnOffButton extends LayeredImageButton {
     }
 
     public GlintSlotOnOffButton(boolean initial, EquipmentSlot slot, int width, int height, OnPress onPress) {
-        super(slot, width, height, initial ? GlintSlotOnOffButton.enabledMsg(slot) : GlintSlotOnOffButton.disabledMsg(slot), onPress);
+        super(slot, initial, width, height, initial ? GlintSlotOnOffButton.enabledMsg(slot) : GlintSlotOnOffButton.disabledMsg(slot), onPress);
         if (slot == EquipmentSlot.HEAD) {
             slotSprite = modSprite("iron_helmet");
         }

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/PresetButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/PresetButton.java
@@ -11,10 +11,9 @@ public class PresetButton extends SquareLayeredTextButton {
     private boolean presetActive;
 
     public PresetButton(int presetIndex, boolean isEmpty, boolean active, OnPress onPress) {
-        super(String.valueOf(presetIndex + 1), message(presetIndex, isEmpty, active), onPress);
+        super(!isEmpty, String.valueOf(presetIndex + 1), message(presetIndex, isEmpty, active), onPress);
         this.presetIndex = presetIndex;
         this.presetActive = active;
-        this.isEnabled = !isEmpty;
     }
 
     public int getPresetIndex() {

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/ShowShieldWhenBlockingButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/ShowShieldWhenBlockingButton.java
@@ -11,9 +11,8 @@ public class ShowShieldWhenBlockingButton extends LayeredImageButton {
     private final Identifier disabledSprite = modSprite("shield_blocking_disabled");
 
     public ShowShieldWhenBlockingButton(boolean initial, int width, int height, OnPress onPress) {
-        super(null, width, height,
+        super(null, initial, width, height,
                 initial ? enabledMsg() : disabledMsg(), onPress);
-        super.setEnabled(initial);
     }
 
     @Override

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/VanillaArmorInCombatButton.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/implementations/VanillaArmorInCombatButton.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 public class VanillaArmorInCombatButton extends LayeredImageButton {
 
     public VanillaArmorInCombatButton(boolean initial, OnPress onPress) {
-        super(null, UiConstants.SQUARE_BUTTON_WIDTH, UiConstants.DEFAULT_BUTTON_HEIGHT,
+        super(null, initial, UiConstants.SQUARE_BUTTON_WIDTH, UiConstants.DEFAULT_BUTTON_HEIGHT,
                 initial ? VanillaArmorInCombatButton.enabledMsg() : VanillaArmorInCombatButton.disabledMsg(), onPress);
     }
 


### PR DESCRIPTION
See #250 - buttons now correctly have their config values supplied in all cases.