### PR TITLE
fix: first person items visible and non transparent, cape suppression, fixes #251

### DIFF
--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/cape/CapeRenderMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/cape/CapeRenderMixin.java
@@ -133,12 +133,8 @@ public class CapeRenderMixin {
         if (result) {
             var mod = ArmorHiderClient.RENDER_CONTEXT.activeModification();
             if (mod != null
-                    && ActiveModification.isSlotFullyHidden(mod.playerName(), EquipmentSlot.CHEST,
-                    //? if >= 1.21.4
-                    item
-                    //? if < 1.21.4
-                    //instance
-                    )) {
+                    && mod.shouldHide()
+                    && itemStackContainsElytra(mod.item()) ) {
                 return false;
             }
         }

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/hand/OffHandRenderMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/hand/OffHandRenderMixin.java
@@ -36,7 +36,10 @@ import net.minecraft.world.level.Level;
 public class OffHandRenderMixin {
 
     @Inject(
-            method = "renderArmWithItem",
+            //? if < 26.2
+            //method = "renderArmWithItem",
+            //? if >= 26.2
+            method = "submitArmWithItem",
             at = @At("HEAD")
     )
     //? if >= 1.21.9
@@ -109,7 +112,10 @@ public class OffHandRenderMixin {
     }
 
     @Inject(
-            method = "renderArmWithItem",
+            //? if < 26.2
+            //method = "renderArmWithItem",
+            //? if >= 26.2
+            method = "submitArmWithItem",
             at = @At("TAIL")
     )
     //? if >= 1.21.9

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/hand/SubmitNodeCollectorMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/hand/SubmitNodeCollectorMixin.java
@@ -30,8 +30,12 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 //import net.minecraft.client.renderer.rendertype.RenderType;
 
 //? if >= 26.2-1.pre {
+import net.minecraft.client.renderer.feature.phase.SimpleFeatureRenderPhase;
 import net.minecraft.client.renderer.feature.phase.TranslucentFeatureRenderPhase;
+import net.minecraft.client.renderer.feature.submit.SubmitNode;
 import net.minecraft.client.renderer.feature.submit.TranslucentSubmit;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Shadow;
 //?}
 
 @SuppressWarnings({"unused", "UnusedMixin"})
@@ -129,6 +133,53 @@ public class SubmitNodeCollectorMixin {
     *///?}
 
     //? if >= 26.2-1.pre {
+    @Shadow @Final public TranslucentFeatureRenderPhase translucentModels;
+
+    /// In 26.2 `submitModel` routes by render-type phase: cutout/solid items (shields,
+    /// banners, tridents in their special-renderer paths) go to `solid.submit(...)`,
+    /// bypassing the translucent submit wrap below. Redirect that solid call into
+    /// `translucentModels` with a translucent render type and alpha-rewritten color so
+    /// off-hand and custom-head modifications actually apply.
+    @WrapOperation(
+            method = "submitModel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/feature/phase/SimpleFeatureRenderPhase;submit(Lnet/minecraft/client/renderer/feature/submit/SubmitNode;)V",
+                    ordinal = 1
+            )
+    )
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void redirectSolidToTranslucentForModifiedSlots(SimpleFeatureRenderPhase solid, SubmitNode node, Operation<Void> original) {
+        if (!(node instanceof ModelFeatureRenderer.Submit<?> modelSubmit)) {
+            original.call(solid, node);
+            return;
+        }
+        var ctx = ArmorHiderClient.RENDER_CONTEXT;
+        if (!ctx.hasActiveModification(EquipmentSlot.OFFHAND) && !ctx.hasActiveModification(EquipmentSlot.HEAD)) {
+            original.call(solid, node);
+            return;
+        }
+
+        float alpha = RenderModifications.getTransparencyAlpha(ctx);
+        int origColor = modelSubmit.tintedColor();
+        int origAlpha = (origColor >> 24) & 0xFF;
+        int newAlpha = Math.round(alpha * origAlpha);
+        int modifiedColor = (origColor & 0x00FFFFFF) | (newAlpha << 24);
+
+        RenderType translucentType = modelSubmit.renderType();
+        if (modelSubmit.sprite() != null) {
+            translucentType = RenderTypeFactory.translucentEntity(modelSubmit.sprite().atlasLocation());
+        }
+
+        var modified = new ModelFeatureRenderer.Submit(
+                translucentType, modelSubmit.pose(), modelSubmit.model(), modelSubmit.state(),
+                modelSubmit.lightCoords(), modelSubmit.overlayCoords(), modifiedColor,
+                modelSubmit.sprite(), modelSubmit.sheetedDecalPose()
+        );
+
+        translucentModels.submit((TranslucentSubmit) modified);
+    }
+
     @WrapOperation(
             method = "submitModel",
             at = @At(


### PR DESCRIPTION
* fixes that offhand items were not translucent / suppressed on certain game versions, see #251 
* adjusts the cape layer for wings to only kick in when the player actually has elytra equipped and it is hidden