### PR TITLE
fix: component load and ci, closes #260

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -286,6 +286,10 @@ jobs:
       needs.check-modrinth.outputs.version_exists != 'true'
     strategy:
       fail-fast: false
+      # Serialize: parallel jobs hammer Modrinth's API and get rate-limited (429). mc-publish
+      # resolves loaders/game-versions against Modrinth's tag endpoints, and a throttled fetch
+      # silently yields empty metadata — the version publishes with no loaders/game_versions.
+      max-parallel: 1
       matrix:
         include: ${{ fromJSON(needs.build.outputs.supported_versions) }}
     steps:
@@ -382,6 +386,8 @@ jobs:
       needs.analyze.outputs.is_manual_release == 'true'
     strategy:
       fail-fast: false
+      # Serialize to avoid the same rate-limit race as Modrinth (see publish-modrinth above).
+      max-parallel: 1
       matrix:
         include: ${{ fromJSON(needs.build.outputs.supported_versions) }}
     steps:

--- a/common/src/client/java/de/zannagh/armorhider/client/render/interceptors/ArmorHiderElytraRenderer.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/render/interceptors/ArmorHiderElytraRenderer.java
@@ -35,7 +35,7 @@ public class ArmorHiderElytraRenderer extends AbstractArmorHiderRenderer {
             setEmptyModification();
             return RenderInterceptionResult.ignore();
         }
-        ItemStack elytraStack = stack != null ? stack : ItemsUtil.ELYTRA_ITEM_STACK;
+        ItemStack elytraStack = stack != null ? stack : ItemsUtil.elytraItemStack();
         var mod = resolveModification(carrier, EquipmentSlot.CHEST, elytraStack);
 
         // Pass-through branches: do NOT enter scope. enterScope-with-mod would still register a

--- a/common/src/main/java/de/zannagh/armorhider/util/ItemsUtil.java
+++ b/common/src/main/java/de/zannagh/armorhider/util/ItemsUtil.java
@@ -26,7 +26,18 @@ public final class ItemsUtil {
                     Items.CREEPER_HEAD,
                     Items.PIGLIN_HEAD));
 
-    public static final ItemStack ELYTRA_ITEM_STACK = new ItemStack(Items.ELYTRA);
+    // Lazily created so this class can be loaded before item registries / data components are
+    // bound. Some UI / picture-in-picture mods force early class loading, and eagerly building an
+    // ItemStack at <clinit> then crashes with "Components not bound yet" (issue #260). The holder
+    // defers construction to first use (render time, registries ready) and is thread-safe via the
+    // JVM class-init lock.
+    private static final class ElytraStackHolder {
+        private static final ItemStack STACK = new ItemStack(Items.ELYTRA);
+    }
+
+    public static ItemStack elytraItemStack() {
+        return ElytraStackHolder.STACK;
+    }
 
     public static ItemStack getItemStackFromSkullBlockType(@Nullable SkullBlock.Type type) {
         if (type == null) {
@@ -61,8 +72,8 @@ public final class ItemsUtil {
             return false;
         }
         //? if < 1.21.9 {
-        /*return itemStack.is(ELYTRA_ITEM_STACK.getItem()) || itemStack.getItem().toString().toLowerCase().contains("elytra");
+        /*return itemStack.is(Items.ELYTRA) || itemStack.getItem().toString().toLowerCase().contains("elytra");
         *///?} else
-        return itemStack.getComponents().has(DataComponents.GLIDER) || itemStack.is(ELYTRA_ITEM_STACK.getItem()) || itemStack.getItem().toString().toLowerCase().contains("elytra");
+        return itemStack.getComponents().has(DataComponents.GLIDER) || itemStack.is(Items.ELYTRA) || itemStack.getItem().toString().toLowerCase().contains("elytra");
     }
 }


### PR DESCRIPTION
See #260 for ItemStack initialization issue.

This fixes component eager loading by lazy loading the required comparison items.

Additionally, limits the parallelism for Modrinth and CF uploads to prevent rate limiting.