### PR TITLE
fix: prevent double-bindings in hotkeys, migrate conflicting presets, glfw instead of awk, closes #261

### DIFF
--- a/common/src/client/java/de/zannagh/armorhider/client/keybinds/LoadPresetKeyMapping.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/keybinds/LoadPresetKeyMapping.java
@@ -4,16 +4,21 @@ import de.zannagh.armorhider.ArmorHider;
 import de.zannagh.armorhider.client.ArmorHiderClient;
 import de.zannagh.armorhider.configuration.ConfigPreset;
 import net.minecraft.client.Minecraft;
-
-import java.awt.event.KeyEvent;
+import org.lwjgl.glfw.GLFW;
 
 public class LoadPresetKeyMapping extends CustomKeyMapping {
+
+    // Left-Alt is uncommon among vanilla defaults. GLFW keycodes only — an AWT VK
+    // value here would mis-map; VK_UNDEFINED (0) in particular collides with the
+    // number-row "0" key (both named "key.keyboard.0").
+    public static final int DEFAULT_KEY = GLFW.GLFW_KEY_LEFT_ALT;
+    public static final int UNBOUND_KEY = GLFW.GLFW_KEY_UNKNOWN;
 
     private static LoadPresetKeyMapping instance;
     private int activatedWhileHeld = -1;
 
-    public LoadPresetKeyMapping() {
-        super("key.armorhider.preset", KeyEvent.VK_UNDEFINED);
+    public LoadPresetKeyMapping(int preferredKey) {
+        super("key.armorhider.preset", preferredKey);
         instance = this;
     }
 

--- a/common/src/client/java/de/zannagh/armorhider/client/keybinds/LoadPresetKeyMapping.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/keybinds/LoadPresetKeyMapping.java
@@ -2,7 +2,6 @@ package de.zannagh.armorhider.client.keybinds;
 
 import de.zannagh.armorhider.ArmorHider;
 import de.zannagh.armorhider.client.ArmorHiderClient;
-import de.zannagh.armorhider.configuration.ConfigPreset;
 import net.minecraft.client.Minecraft;
 import org.lwjgl.glfw.GLFW;
 
@@ -12,7 +11,6 @@ public class LoadPresetKeyMapping extends CustomKeyMapping {
     // value here would mis-map; VK_UNDEFINED (0) in particular collides with the
     // number-row "0" key (both named "key.keyboard.0").
     public static final int DEFAULT_KEY = GLFW.GLFW_KEY_LEFT_ALT;
-    public static final int UNBOUND_KEY = GLFW.GLFW_KEY_UNKNOWN;
 
     private static LoadPresetKeyMapping instance;
     private int activatedWhileHeld = -1;

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/OptionsMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/OptionsMixin.java
@@ -1,5 +1,6 @@
 package de.zannagh.armorhider.client.mixin;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import de.zannagh.armorhider.client.keybinds.*;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
@@ -41,34 +42,44 @@ public class OptionsMixin {
             existingMappings.add(new OpenSettingsKeyMapping());
         }
         if (!hasPresetMapping) {
-            existingMappings.add(new LoadPresetKeyMapping(pickPresetDefaultKey()));
+            existingMappings.add(new LoadPresetKeyMapping(LoadPresetKeyMapping.DEFAULT_KEY));
         }
         keyMappings = existingMappings.toArray(new KeyMapping[0]);
     }
 
-    private int pickPresetDefaultKey() {
-        boolean defaultTaken = Arrays.stream(keyMappings)
-                .anyMatch(map -> map.getDefaultKey().getValue() == LoadPresetKeyMapping.DEFAULT_KEY);
-        return defaultTaken ? LoadPresetKeyMapping.UNBOUND_KEY : LoadPresetKeyMapping.DEFAULT_KEY;
-    }
-
-    // Reset a preset binding left on the legacy corrupt "0" value back to its default.
-    // Runs after vanilla applies saved keys, so saveString reflects the persisted value.
+    // Resolve the preset modifier only when its *current* (post-load) binding is
+    // problematic: the legacy corrupt "0" or our own Left-Alt default colliding with
+    // another mapping. A deliberate, non-default user binding is never touched.
     @Inject(
             method = "load",
             at = @At("RETURN")
     )
     private void onLoadReturn(CallbackInfo ci) {
-        boolean migrated = false;
+        LoadPresetKeyMapping preset = null;
         for (KeyMapping map : keyMappings) {
-            if (map instanceof LoadPresetKeyMapping && ARMORHIDER_LEGACY_PRESET_KEY.equals(map.saveString())) {
-                map.setKey(map.getDefaultKey());
-                migrated = true;
+            if (map instanceof LoadPresetKeyMapping p) {
+                preset = p;
+                break;
             }
         }
-        if (migrated) {
-            KeyMapping.resetMapping();
-            ((Options) (Object) this).save();
+        if (preset == null) {
+            return;
         }
+
+        String currentKey = preset.saveString();
+        String defaultKey = preset.getDefaultKey().getName();
+        boolean isResolvable = ARMORHIDER_LEGACY_PRESET_KEY.equals(currentKey) || defaultKey.equals(currentKey);
+        if (!isResolvable || !isKeyInUse(preset, currentKey)) {
+            return;
+        }
+
+        preset.setKey(isKeyInUse(preset, defaultKey) ? InputConstants.UNKNOWN : preset.getDefaultKey());
+        KeyMapping.resetMapping();
+        ((Options) (Object) this).save();
+    }
+
+    private boolean isKeyInUse(KeyMapping exclude, String keyName) {
+        return Arrays.stream(keyMappings)
+                .anyMatch(map -> map != exclude && map.saveString().equals(keyName));
     }
 }

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/OptionsMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/OptionsMixin.java
@@ -11,11 +11,17 @@ import java.util.Arrays;
 
 @Mixin(Options.class)
 public class OptionsMixin {
+
+    // Legacy corrupt binding: older builds defaulted the preset key to keycode 0,
+    // which serialized as "key.keyboard.0" and clobbered the number-row "0" key.
+    @Unique
+    private static final String ARMORHIDER_LEGACY_PRESET_KEY = "key.keyboard.0";
+
     @Mutable
     @Shadow
     @Final
     public KeyMapping[] keyMappings;
-    
+
     @Inject(
             method = "load",
             at = @At("HEAD")
@@ -35,8 +41,34 @@ public class OptionsMixin {
             existingMappings.add(new OpenSettingsKeyMapping());
         }
         if (!hasPresetMapping) {
-            existingMappings.add(new LoadPresetKeyMapping());
+            existingMappings.add(new LoadPresetKeyMapping(pickPresetDefaultKey()));
         }
         keyMappings = existingMappings.toArray(new KeyMapping[0]);
+    }
+
+    private int pickPresetDefaultKey() {
+        boolean defaultTaken = Arrays.stream(keyMappings)
+                .anyMatch(map -> map.getDefaultKey().getValue() == LoadPresetKeyMapping.DEFAULT_KEY);
+        return defaultTaken ? LoadPresetKeyMapping.UNBOUND_KEY : LoadPresetKeyMapping.DEFAULT_KEY;
+    }
+
+    // Reset a preset binding left on the legacy corrupt "0" value back to its default.
+    // Runs after vanilla applies saved keys, so saveString reflects the persisted value.
+    @Inject(
+            method = "load",
+            at = @At("RETURN")
+    )
+    private void onLoadReturn(CallbackInfo ci) {
+        boolean migrated = false;
+        for (KeyMapping map : keyMappings) {
+            if (map instanceof LoadPresetKeyMapping && ARMORHIDER_LEGACY_PRESET_KEY.equals(map.saveString())) {
+                map.setKey(map.getDefaultKey());
+                migrated = true;
+            }
+        }
+        if (migrated) {
+            KeyMapping.resetMapping();
+            ((Options) (Object) this).save();
+        }
     }
 }


### PR DESCRIPTION
see #261 

This PR:
* makes keybinds use GLFW instead of AWT
* rebinds conflicting (or nonsensical) previous preset keybinds to Left-Alt as default (if not in use, otherwise unbound)
* changes the default keybind of preset key modifier from misinterpreted undefined (was set to '0' by GLFW/AWT mismatch) to Left-Alt