### PR TITLE
fix: method remap on non-mod-specific method

### DIFF
--- a/common/src/client/java/de/zannagh/armorhider/client/api/readme.md
+++ b/common/src/client/java/de/zannagh/armorhider/client/api/readme.md
@@ -37,7 +37,7 @@ public class MyCapeRenderer extends AbstractArmorHiderRenderer {
     @Override public RenderScope getTargetScope() { return RenderScope.CAPE; }
     @Override public RenderInterceptionResult interceptFrom(IdentityCarrier carrier, CallbackInfo ci) {
         // ... compute the modification you want; call super for the standard path
-        return standardIntercept(carrier, EquipmentSlot.CHEST, carrier.getItemBySlot(EquipmentSlot.CHEST), ci);
+        return standardIntercept(carrier, EquipmentSlot.CHEST, carrier.armorHider$getItemBySlot(EquipmentSlot.CHEST), ci);
     }
 }
 

--- a/common/src/client/java/de/zannagh/armorhider/client/common/EquippableInformation.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/common/EquippableInformation.java
@@ -47,7 +47,7 @@ public class EquippableInformation {
                 return;
             }
             if (slot != null && stack == null) {
-                this.stack = identityCarrier.getItemBySlot(slot);
+                this.stack = identityCarrier.armorHider$getItemBySlot(slot);
                 this.slot = slot;
                 this.itemInfo = new ItemInfo(this.stack);
                 isValid = true;

--- a/common/src/client/java/de/zannagh/armorhider/client/common/IdentityCarrier.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/common/IdentityCarrier.java
@@ -34,7 +34,10 @@ public interface IdentityCarrier {
                 && mods.feet().shouldHide();
     }
 
-    @NonNull ItemStack getItemBySlot(EquipmentSlot slot);
+    // Uniquely namespaced: the name must NOT collide with the vanilla LivingEntity#getItemBySlot,
+    // otherwise in a remapped (production) environment Player has no method matching this interface
+    // signature and any interface-typed call throws AbstractMethodError.
+    @NonNull ItemStack armorHider$getItemBySlot(EquipmentSlot slot);
 
     /**
      * Creates a rendering modification for the given equipment slot and item without setting the render context.

--- a/common/src/client/java/de/zannagh/armorhider/client/compat/FantasyArmorCompat.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/compat/FantasyArmorCompat.java
@@ -27,7 +27,7 @@ public final class FantasyArmorCompat {
             return;
         }
 
-        if (SlotModification.isSlotModified(name, EquipmentSlot.CHEST, carrier.getItemBySlot(EquipmentSlot.CHEST))) {
+        if (SlotModification.isSlotModified(name, EquipmentSlot.CHEST, carrier.armorHider$getItemBySlot(EquipmentSlot.CHEST))) {
             //? if >= 1.21.4
             var model = ((LivingEntityRenderer<?, ?, ?>) (Object) playerModel).getModel();
             //? if < 1.21.4
@@ -56,7 +56,7 @@ public final class FantasyArmorCompat {
         if (!(state instanceof IdentityCarrier carrier)) {
             return;
         }
-        var mod = SlotModification.of(carrier.armorHider$playerName(), EquipmentSlot.CHEST, carrier.getItemBySlot(EquipmentSlot.CHEST));
+        var mod = SlotModification.of(carrier.armorHider$playerName(), EquipmentSlot.CHEST, carrier.armorHider$getItemBySlot(EquipmentSlot.CHEST));
         if (!mod.needsModification()) {
             return;
         }

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/LivingEntityRenderStateMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/LivingEntityRenderStateMixin.java
@@ -78,8 +78,8 @@ public class LivingEntityRenderStateMixin implements IdentityStateCarrier {
     }
 
     @Override
-    public @NonNull ItemStack getItemBySlot(EquipmentSlot slot) {
-        return armorHider$carrier == null ? ItemStack.EMPTY : armorHider$carrier.getItemBySlot(slot);
+    public @NonNull ItemStack armorHider$getItemBySlot(EquipmentSlot slot) {
+        return armorHider$carrier == null ? ItemStack.EMPTY : armorHider$carrier.armorHider$getItemBySlot(slot);
     }
 
 }

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/PlayerMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/PlayerMixin.java
@@ -24,6 +24,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -110,6 +111,7 @@ public abstract class PlayerMixin
     }
 
     @Override
+    @NonNull
     public ItemStack armorHider$getItemBySlot(EquipmentSlot slot) {
         return ((Player) (Object) this).getItemBySlot(slot);
     }

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/PlayerMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/PlayerMixin.java
@@ -110,6 +110,11 @@ public abstract class PlayerMixin
     }
 
     @Override
+    public ItemStack armorHider$getItemBySlot(EquipmentSlot slot) {
+        return ((Player) (Object) this).getItemBySlot(slot);
+    }
+
+    @Override
     public @Nullable ItemStack customHeadItem() {
         Player player = (Player) (Object) this;
         ItemStack head = player.getItemBySlot(EquipmentSlot.HEAD);

--- a/common/src/client/java/de/zannagh/armorhider/client/render/interceptors/ArmorHiderCapeRenderer.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/render/interceptors/ArmorHiderCapeRenderer.java
@@ -31,7 +31,7 @@ public class ArmorHiderCapeRenderer extends AbstractArmorHiderRenderer {
             setEmptyModification();
             return RenderInterceptionResult.ignore();
         }
-        ItemStack chest = stack != null ? stack : carrier.getItemBySlot(EquipmentSlot.CHEST);
+        ItemStack chest = stack != null ? stack : carrier.armorHider$getItemBySlot(EquipmentSlot.CHEST);
         var mod = resolveModification(carrier, EquipmentSlot.CHEST, chest);
         if (mod.isEmpty()) {
             return RenderInterceptionResult.ignore();

--- a/common/src/client/java/de/zannagh/armorhider/client/render/interceptors/ArmorHiderOffhandRenderer.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/render/interceptors/ArmorHiderOffhandRenderer.java
@@ -37,7 +37,7 @@ public class ArmorHiderOffhandRenderer extends AbstractArmorHiderRenderer {
             setEmptyModification();
             return RenderInterceptionResult.ignore();
         }
-        ItemStack offhand = stack != null ? stack : carrier.getItemBySlot(slot);
+        ItemStack offhand = stack != null ? stack : carrier.armorHider$getItemBySlot(slot);
         if (offhand.isEmpty()) {
             resolveModification(carrier, slot, ItemStack.EMPTY);
             return RenderInterceptionResult.ignore();


### PR DESCRIPTION
Should fix a startup crash when method remapping fails due to interface using a vanilla method name.