### PR TITLE
ci: use fork of mc-publish to bump node from 16 to 24 (and remove CI warnings)

### DIFF
--- a/.github/workflows/publish-existing-release.yml
+++ b/.github/workflows/publish-existing-release.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Publish to Modrinth
         if: ${{ steps.modrinth.outputs.found == 'true' && !inputs.dry_run }}
-        uses: Kira-NT/mc-publish@v3.3
+        uses: zannagh/mc-publish@v3.3.1
         with:
           modrinth-id: ${{ env.MODRINTH_PROJECT_ID }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -327,7 +327,7 @@ jobs:
 
       - name: Publish to CurseForge
         if: ${{ steps.curseforge.outputs.found == 'true' && !inputs.dry_run }}
-        uses: Kira-NT/mc-publish@v3.3
+        uses: zannagh/mc-publish@v3.3.1
         with:
           curseforge-id: ${{ env.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -355,7 +355,7 @@ jobs:
 
       - name: Publish to Modrinth
         if: ${{ steps.modrinth.outputs.found == 'true' && env.PUBLISH_TO_MODRINTH == 'true' && !inputs.dry_run }}
-        uses: Kira-NT/mc-publish@v3.3
+        uses: zannagh/mc-publish@v3.3.1
         with:
           modrinth-id: ${{ env.MODRINTH_PROJECT_ID }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -453,7 +453,7 @@ jobs:
 
       - name: Publish to CurseForge
         if: ${{ steps.curseforge.outputs.found == 'true' && env.PUBLISH_TO_CURSEFORGE == 'true' && !inputs.dry_run }}
-        uses: Kira-NT/mc-publish@v3.3
+        uses: zannagh/mc-publish@v3.3.1
         with:
           curseforge-id: ${{ env.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}


### PR DESCRIPTION
This PR switches mc-publish to a fork that uses node 24 instead of 16