### PR TITLE
fix: commonize trim color adjustments between fabric/neo, fixes #276

### DIFF
--- a/common/src/client/java/de/zannagh/armorhider/client/api/AhRenderModificationApi.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/api/AhRenderModificationApi.java
@@ -107,11 +107,12 @@ public interface AhRenderModificationApi {
     int applyArmorTransparency(int originalColor);
 
     /**
-     * Produce a translucent white color (alpha scaled by the active transparency) from a packed
-     * overlay value. Used by render layers that drive their color from {@code packedOverlay} —
-     * the original value is returned when no modification is active.
+     * Produce a translucent white color (opaque white with its alpha scaled by the active
+     * transparency). Used by render layers whose vanilla color is white (e.g. armor trims,
+     * skulls). Returns opaque white ({@code 0xFFFFFFFF}) when no modification is active, so
+     * callers never have to supply — or accidentally mis-supply — a fallback color.
      */
-    int applyTransparencyFromWhite(int original);
+    int applyTransparencyFromWhite();
 
     /**
      * @return the active transparency as an alpha factor in {@code [0.0, 1.0]}, or {@code 1.0} when

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/EquipmentRenderMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/EquipmentRenderMixin.java
@@ -341,7 +341,7 @@ public class EquipmentRenderMixin {
             original.call(model, poseStack, vertexConsumer, packedLight, packedOverlay);
             return;
         }
-        int color = ctx.renderModificationApi().applyTransparencyFromWhite(0xFFFFFFFF);
+        int color = ctx.renderModificationApi().applyTransparencyFromWhite();
         model.renderToBuffer(poseStack, vertexConsumer, packedLight, packedOverlay, color);
     }
     *///?}

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/HumanoidArmorLayerMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/HumanoidArmorLayerMixin.java
@@ -172,7 +172,7 @@ public class HumanoidArmorLayerMixin
     private void modifyTrimColor(A model, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, int packedOverlay, Operation<Void> original) {
         var ctx = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE);
         if (ctx.isEmpty()) { original.call(model, poseStack, vertexConsumer, packedLight, packedOverlay); return; }
-        int modifiedColor = ctx.renderModificationApi().applyTransparencyFromWhite(0xFFFFFFFF);
+        int modifiedColor = ctx.renderModificationApi().applyTransparencyFromWhite();
         model.renderToBuffer(poseStack, vertexConsumer, packedLight, packedOverlay, modifiedColor);
     }
     *///?}

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/head/SkullBlockRenderMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/head/SkullBlockRenderMixin.java
@@ -63,9 +63,9 @@ public abstract class SkullBlockRenderMixin {
             return;
         }
         // Short-circuit on !needsModification, not just isEmpty: the scope is non-empty whenever
-        // a slot modification is in effect (even for full opacity), and falling through to
-        // applyTransparencyFromWhite with the no-modification fallback color invisibly returns
-        // 255 (= ARGB 0x000000FF, alpha 0), which would render the skull as transparent black.
+        // a slot modification is in effect (even for full opacity). When nothing needs to change
+        // we want the exact vanilla call — not the rebuilt submit with a priority reorder below —
+        // so full-opacity skulls keep their original render path untouched.
         if (!headCtx.needsModification()) {
             //? if >= 26.3-0.snapshot.2 {
             /*original.call(instance, model, o, poseStack, renderType, i, j, k);
@@ -84,13 +84,13 @@ public abstract class SkullBlockRenderMixin {
         // Passing the transparency color there painted a selection-style outline and left the skull
         // fully opaque. Call the 9-arg form directly so the alpha-reduced color lands in the real
         // color slot; the original 3rd int (i, j, k = light, overlay, outlineColor) is preserved.
-        var modifiedColor = headCtx.renderModificationApi().applyTransparencyFromWhite(0xFFFFFFFF);
+        var modifiedColor = headCtx.renderModificationApi().applyTransparencyFromWhite();
         instance.order(RenderModifications.SKULL_RENDER_PRIORITY).submitModel(model, o, poseStack, renderType, i, j, modifiedColor, null, k);
         *///? } elif >= 1.21.9 {
-        var modifiedColor = headCtx.renderModificationApi().applyTransparencyFromWhite(0xFFFFFFFF);
+        var modifiedColor = headCtx.renderModificationApi().applyTransparencyFromWhite();
         instance.order(RenderModifications.SKULL_RENDER_PRIORITY).submitModel(model, o, poseStack, renderType, i, j, modifiedColor, null, k, crumblingOverlay);
         //? } elif >= 1.21 {
-        /*int modifiedColor = headCtx.renderModificationApi().applyTransparencyFromWhite(0xFFFFFFFF);
+        /*int modifiedColor = headCtx.renderModificationApi().applyTransparencyFromWhite();
         instance.renderToBuffer(poseStack, vertexConsumer, light, overlay, modifiedColor);*/
         //? } else {
         /*float newAlpha = headCtx.renderModificationApi().getTransparencyAlpha();

--- a/common/src/client/java/de/zannagh/armorhider/client/render/RenderModifications.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/render/RenderModifications.java
@@ -87,9 +87,14 @@ public class RenderModifications implements AhRenderModificationApi {
         return colors().applyTransparency(originalColor, (float) slotModification.transparency());
     }
 
-    public int applyTransparencyFromWhite(int original) {
+    public int applyTransparencyFromWhite() {
         if (slotModification.isEmpty() || !slotModification.needsModification()) {
-            return original;
+            // Opaque white is the no-op tint for a white-based render (vanilla renders these
+            // pieces with color -1). Returning a caller-supplied fallback here is a footgun:
+            // passing anything else (e.g. packedOverlay) tints the piece invisible when the
+            // modification is inert. Keeping the fallback in one place is what lets both
+            // loaders' mixins call this identically without drifting.
+            return 0xFFFFFFFF;
         }
         return colors().whiteWithTransparency((float) slotModification.transparency());
     }

--- a/neoforge/src/main/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/NeoForgeHumanoidArmorLayerMixin.java
+++ b/neoforge/src/main/java/de/zannagh/armorhider/client/mixin/bodyKneesAndToes/NeoForgeHumanoidArmorLayerMixin.java
@@ -134,7 +134,7 @@ public class NeoForgeHumanoidArmorLayerMixin<T extends LivingEntity, M extends H
             require = 0
     )
     private void modifyTrimColor(Model model, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, int packedOverlay, Operation<Void> original) {
-        int modifiedColor = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE).renderModificationApi().applyTransparencyFromWhite(packedOverlay);
+        int modifiedColor = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE).renderModificationApi().applyTransparencyFromWhite();
         model.renderToBuffer(poseStack, vertexConsumer, packedLight, packedOverlay, modifiedColor);
     }
 }


### PR DESCRIPTION
see #276 

This PR homogenizes how trim colors are calculated between NeoForge and Fabric. Additionally it disregards the original parameter that is practically inert.