### PR TITLE
fix: config payload sizes and UI tick issue

### DIFF
--- a/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
@@ -242,7 +242,7 @@ if (branch == "fabric") {
     // that pin `fabricapi.semver` (currently fabric-26.2). Other variants emit "[]" so the
     // JSON stays valid and fabric-loader simply ignores it.
     val fcgtEntries = if (hasProperty("fabricapi.semver"))
-        "[\"de.zannagh.armorhider.smoke.EntityRenderSmokeTest\", \"de.zannagh.armorhider.smoke.IndividualConfigSmokeTest\"]"
+        "[\"de.zannagh.armorhider.smoke.EntityRenderSmokeTest\", \"de.zannagh.armorhider.smoke.IndividualConfigSmokeTest\", \"de.zannagh.armorhider.smoke.KeybindSmokeTest\"]"
     else
         "[]"
 

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/elements/factories/OptionElementFactory.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/elements/factories/OptionElementFactory.java
@@ -358,8 +358,11 @@ public class OptionElementFactory {
                 key,
                 new NarratedTooltipFactory<>(tooltip, narration),
                 (text, value) -> sliderTextProvider.apply(value),
+                // The trailing flag is applyValueImmediately. It MUST stay false: with it on, the setter
+                // fires on every drag step, and each call writes the whole preset file to disk
+                // synchronously on the render thread — enough to starve frames and input on a slider drag.
                 //? if >= 1.21.11
-                new OptionInstance.IntRange(0, 20).xmap(v -> v / 20.0, v -> (int) Math.round(v * 20), true)
+                new OptionInstance.IntRange(0, 20).xmap(v -> v / 20.0, v -> (int) Math.round(v * 20), false)
                 //? if >= 1.20.5 && < 1.21.11
                 //new OptionInstance.IntRange(0, 20).xmap(v -> v / 20.0, v -> (int) Math.round(v * 20))
                 //? if < 1.20.5

--- a/common/src/client/java/de/zannagh/armorhider/client/gui/screens/ArmorHiderConfigurationScreen.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/gui/screens/ArmorHiderConfigurationScreen.java
@@ -1,5 +1,6 @@
 package de.zannagh.armorhider.client.gui.screens;
 
+import de.zannagh.armorhider.ArmorHider;
 import de.zannagh.armorhider.client.ArmorHiderClient;
 import de.zannagh.armorhider.client.gui.elements.factories.OptionElementFactory;
 import de.zannagh.armorhider.client.gui.elements.WidgetList;
@@ -71,10 +72,21 @@ public abstract class ArmorHiderConfigurationScreen extends Screen {
     
     @Override
     public void onClose() {
-        if (settingsChanged) {
-            saveSettingsOnClose();
+        // Navigation happens in the finally block: if saving throws, the screen must still close. Previously
+        // an exception here (e.g. Gson refusing a non-finite value, or a dropped connection while pushing the
+        // config) left the screen permanently mounted with no way out — and since the offending value was on
+        // disk, it recurred on every launch until the config file was deleted.
+        try {
+            if (settingsChanged) {
+                saveSettingsOnClose();
+            }
+            // Settings edits only touch the active preset in memory; this is the one write per visit.
+            ArmorHiderClient.PRESET_MANAGER.flushPendingSave();
+        } catch (Exception e) {
+            ArmorHider.LOGGER.error("Failed to save Armor Hider settings on close.", e);
+        } finally {
+            this.minecraft.setScreenAndShow(parent);
         }
-        this.minecraft.setScreenAndShow(parent);
     }
     
     //? if < 1.21.4 {

--- a/common/src/client/java/de/zannagh/armorhider/client/keybinds/CustomKeyMapping.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/keybinds/CustomKeyMapping.java
@@ -1,29 +1,63 @@
 package de.zannagh.armorhider.client.keybinds;
 
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 
+/**
+ * Base class for the mod's key mappings.
+ * <p>
+ * Actions are edge-triggered from the client tick via {@link #consumeClick()}, never from a
+ * {@code setDown} override. Vanilla calls {@code setDown} for reasons that are not key presses:
+ * {@code Minecraft#setScreen(non-null)} runs {@code KeyMapping.releaseAll()}, and closing a screen
+ * runs {@code MouseHandler#grabMouse()} which calls {@code KeyMapping.setAll()} whenever
+ * {@code InputQuirks.RESTORE_KEY_STATE_AFTER_MOUSE_GRAB} is set — that flag is {@code !ON_OSX}, so it
+ * is on for Windows/Linux and off for macOS. Running an action from {@code setDown} therefore made
+ * "close a screen while the bound key is physically held" re-fire the action, which turned the
+ * open-settings binding into an inescapable re-open loop on Windows/Linux only.
+ * <p>
+ * Click counts are incremented solely for genuine presses and are zeroed by {@code release()} on
+ * every screen open, so this path cannot re-fire on a screen transition and behaves identically on
+ * every OS. The trade-off is that presses are ignored while a screen is open, matching how vanilla
+ * and every other mod's keybinds behave.
+ */
 public abstract class CustomKeyMapping extends KeyMapping {
-    
+
     public CustomKeyMapping(String name, int preferredKey) {
         //? if > 1.21.8
         super(name, preferredKey, Category.MISC);
         //? if <= 1.21.8
          //super(name, preferredKey, "key.categories.misc");
     }
-    
-    
-    @Override
-    public void setDown(boolean down) {
-        if (!down) {
-            onKeyUp();
-            super.setDown(false);
+
+    /**
+     * Drains pending presses for every armor-hider mapping. Called once per client tick.
+     * Iterates the live options array rather than a static registry so mappings can never leak.
+     */
+    public static void armorHider$tickAll(Minecraft minecraft) {
+        if (minecraft == null || minecraft.options == null) {
             return;
         }
-        onKeyDown();
-        super.setDown(true);
+        for (KeyMapping mapping : minecraft.options.keyMappings) {
+            if (mapping instanceof CustomKeyMapping custom) {
+                custom.armorHider$drainClicks();
+            }
+        }
     }
-    
-    public abstract void onKeyDown();
-    
-    public abstract void onKeyUp();
+
+    /**
+     * Collapses however many presses queued up since the last tick into a single activation, so a
+     * burst of presses can never open one screen per press.
+     */
+    private void armorHider$drainClicks() {
+        boolean pressed = false;
+        while (consumeClick()) {
+            pressed = true;
+        }
+        if (pressed) {
+            armorHider$onActivated();
+        }
+    }
+
+    /** Runs once per press, on the client tick following it. */
+    protected abstract void armorHider$onActivated();
 }

--- a/common/src/client/java/de/zannagh/armorhider/client/keybinds/LoadPresetKeyMapping.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/keybinds/LoadPresetKeyMapping.java
@@ -28,16 +28,21 @@ public class LoadPresetKeyMapping extends CustomKeyMapping {
         instance = this;
     }
 
+    // This mapping is a hold-modifier, not a press-action: the work happens in tick() while the key
+    // is held down, so a press on its own does nothing.
     @Override
-    public void onKeyDown() {}
-
-    @Override
-    public void onKeyUp() {
-        activatedWhileHeld = -1;
-    }
+    protected void armorHider$onActivated() {}
 
     public static void tick() {
-        if (instance == null || !instance.isDown()) {
+        if (instance == null) {
+            return;
+        }
+        // isDown() is the right state to read for a hold-modifier, and it is safe to read: vanilla
+        // clears it via releaseAll() when a screen opens and restores it via setAll() when one
+        // closes. Resetting here (rather than from a setDown override) keeps the latch honest on
+        // both paths and on every OS.
+        if (!instance.isDown()) {
+            instance.activatedWhileHeld = -1;
             return;
         }
         var mc = Minecraft.getInstance();

--- a/common/src/client/java/de/zannagh/armorhider/client/keybinds/OpenSettingsKeyMapping.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/keybinds/OpenSettingsKeyMapping.java
@@ -15,18 +15,18 @@ public class OpenSettingsKeyMapping extends CustomKeyMapping {
     }
 
     @Override
-    public void onKeyDown() {
+    protected void armorHider$onActivated() {
         var client = Minecraft.getInstance();
         if (client == null) {
             return;
         }
+        // Presses only register while no screen is open, so this is normally null and closing the
+        // settings screen returns to the world. Read it anyway so the parent stays correct if a
+        // future path ever triggers this with a screen already up.
         //? if <= 26.1.2
         //var currentScreen = client.screen;
         //? if > 26.1.2
         var currentScreen = client.gui.screen();
         McClientUtils.openPreferredSettingsScreen(currentScreen, client.options);
     }
-
-    @Override
-    public void onKeyUp() { }
 }

--- a/common/src/client/java/de/zannagh/armorhider/client/keybinds/ToggleOffKeyMapping.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/keybinds/ToggleOffKeyMapping.java
@@ -16,7 +16,7 @@ public class ToggleOffKeyMapping extends CustomKeyMapping {
     }
     
     @Override
-    public void onKeyDown() {
+    protected void armorHider$onActivated() {
         // Flip the transient session override only — never persisted, cleared on disconnect/restart. The old
         // behaviour wrote to disk and survived restarts and config migrations, so an accidental press could
         // silently disable the mod "forever" until the config file was deleted. Feedback on the action bar
@@ -26,7 +26,4 @@ public class ToggleOffKeyMapping extends CustomKeyMapping {
                 ? "armorhider.toggle.disabled"
                 : "armorhider.toggle.enabled"));
     }
-
-    @Override
-    public void onKeyUp() { }
 }

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/MinecraftClientMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/MinecraftClientMixin.java
@@ -1,5 +1,6 @@
 package de.zannagh.armorhider.client.mixin;
 
+import de.zannagh.armorhider.client.keybinds.CustomKeyMapping;
 import de.zannagh.armorhider.client.keybinds.LoadPresetKeyMapping;
 import de.zannagh.armorhider.client.net.ClientConnectionEvents;
 import net.minecraft.client.Minecraft;
@@ -13,6 +14,7 @@ public class MinecraftClientMixin {
 
     @Inject(method = "tick", at = @At("HEAD"))
     private void tickPresetKeybind(CallbackInfo ci) {
+        CustomKeyMapping.armorHider$tickAll((Minecraft) (Object) this);
         LoadPresetKeyMapping.tick();
     }
 

--- a/common/src/client/java/de/zannagh/armorhider/client/net/ClientCommunicationManager.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/net/ClientCommunicationManager.java
@@ -89,7 +89,15 @@ public final class ClientCommunicationManager {
                 ArmorHiderClient.permissionLevel = 4; // local -> admin
             }
 
-            ClientPacketSender.sendToServer(currentConfig.forNetwork());
+            // A send failure must never abort the join. ClientPacketSender already swallows the
+            // "server doesn't know this channel" case, but the encoder can still reject an oversized
+            // payload and the connection can drop between the check and the write — neither is worth
+            // taking the client down for, since the config is client-authoritative anyway.
+            try {
+                ClientPacketSender.sendToServer(currentConfig.forNetwork());
+            } catch (Exception e) {
+                ArmorHider.LOGGER.warn("Could not send the local config to the server on join.", e);
+            }
 
             // Remind the viewer if Armor Hider is disabled by their saved setting, so a persisted "off" never
             // looks like the mod silently broke. Reads the persisted flag directly (the transient keybind

--- a/common/src/client/java/de/zannagh/armorhider/smoke/KeybindSmokeTest.java
+++ b/common/src/client/java/de/zannagh/armorhider/smoke/KeybindSmokeTest.java
@@ -1,0 +1,193 @@
+//? if fcgt {
+package de.zannagh.armorhider.smoke;
+
+import de.zannagh.armorhider.ArmorHider;
+import de.zannagh.armorhider.client.ArmorHiderClient;
+import de.zannagh.armorhider.client.gui.screens.ArmorHiderOptionsScreen;
+import de.zannagh.armorhider.client.keybinds.CustomKeyMapping;
+import de.zannagh.armorhider.client.keybinds.OpenSettingsKeyMapping;
+import de.zannagh.armorhider.client.keybinds.ToggleOffKeyMapping;
+import net.fabricmc.fabric.api.client.gametest.v1.FabricClientGameTest;
+import net.fabricmc.fabric.api.client.gametest.v1.context.ClientGameTestContext;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.worldselection.WorldCreationUiState;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Regression smoke for the mod's key mappings (settings-screen re-open loop).
+ * <p>
+ * The original bug: {@link CustomKeyMapping} ran its action from a {@code setDown} override. Vanilla calls
+ * {@code setDown} for things that are not key presses — {@code KeyMapping.releaseAll()} on every screen open,
+ * and {@code KeyMapping.setAll()} from {@code MouseHandler#grabMouse()} when a screen closes. The latter is
+ * gated on {@code InputQuirks.RESTORE_KEY_STATE_AFTER_MOUSE_GRAB}, which is {@code !ON_OSX}, so on
+ * Windows/Linux closing the settings screen while the key was still held re-opened it forever.
+ * <p>
+ * These checks pin the invariant that makes that impossible on <em>every</em> OS: {@code setDown} is inert,
+ * and only a real press activates a mapping. A macOS host cannot exercise the {@code setAll()} path at all,
+ * so "{@code setDown} does nothing" is the portable form of the same guarantee — on a Windows/Linux runner
+ * {@link #assertClosingDoesNotReopen} additionally reproduces the original user action end to end.
+ */
+public final class KeybindSmokeTest implements FabricClientGameTest {
+
+    @Override
+    public void runTest(ClientGameTestContext context) {
+        ArmorHider.LOGGER.info("[smoke/fcgt] Keybind smoke starting");
+        context.waitForScreen(TitleScreen.class);
+
+        try (var singleplayer = context.worldBuilder()
+                .setUseConsistentSettings(true)
+                .adjustSettings(state -> {
+                    state.setGameMode(WorldCreationUiState.SelectedGameMode.CREATIVE);
+                    state.setGenerateStructures(false);
+                })
+                .create()) {
+
+            // The open-settings action honours showSettingsInSkinCustomization, which would route to the
+            // vanilla skin screen instead. Pin it off so the assertions have one expected screen type.
+            boolean priorSkinCustomization = context.computeOnClient(client ->
+                    ArmorHiderClient.CLIENT_CONFIG_MANAGER.getLocalPlayerConfig()
+                            .showSettingsInSkinCustomization.getValue());
+            context.runOnClient(client -> ArmorHiderClient.CLIENT_CONFIG_MANAGER.getLocalPlayerConfig()
+                    .showSettingsInSkinCustomization.setValue(false));
+
+            try {
+                assertSetDownIsInert(context);
+                assertPressOpensSettings(context);
+                assertClosingDoesNotReopen(context);
+                assertToggleKeyFlipsSessionOverride(context);
+            } finally {
+                context.runOnClient(client -> ArmorHiderClient.CLIENT_CONFIG_MANAGER.getLocalPlayerConfig()
+                        .showSettingsInSkinCustomization.setValue(priorSkinCustomization));
+            }
+
+            ArmorHider.LOGGER.info("[smoke/fcgt] Keybind checks passed");
+        }
+    }
+
+    /**
+     * The regression guard. Driving {@code setDown} directly — exactly what {@code KeyMapping.setAll()} does
+     * on a mouse re-grab — must not open anything. This is the OS-independent form of the fix.
+     */
+    private static void assertSetDownIsInert(ClientGameTestContext context) {
+        context.runOnClient(client -> {
+            closeAnyScreen(client);
+            var openSettings = mapping(client, OpenSettingsKeyMapping.class);
+            openSettings.setDown(true);
+            openSettings.setDown(false);
+        });
+        context.waitTicks(5);
+        context.runOnClient(client -> {
+            Screen screen = currentScreen(client);
+            if (screen != null) {
+                throw new IllegalStateException("[smoke/fcgt] setDown opened a screen ("
+                        + screen.getClass().getName() + ") — the re-open loop is back");
+            }
+        });
+        ArmorHider.LOGGER.info("[smoke/fcgt] setDown is inert");
+    }
+
+    /** A real key press must open the settings screen. */
+    private static void assertPressOpensSettings(ClientGameTestContext context) {
+        context.runOnClient(KeybindSmokeTest::closeAnyScreen);
+        // Hoisted to a typed local: passing computeOnClient(...) straight into pressKey leaves T open and
+        // makes the KeyMapping / Function<Options, KeyMapping> overloads ambiguous.
+        final KeyMapping openSettings = resolveMapping(context, OpenSettingsKeyMapping.class);
+        context.getInput().pressKey(openSettings);
+        context.waitTicks(5);
+        context.runOnClient(client -> {
+            Screen screen = currentScreen(client);
+            if (!(screen instanceof ArmorHiderOptionsScreen)) {
+                throw new IllegalStateException(
+                        "[smoke/fcgt] the open-settings keybind did not open ArmorHiderOptionsScreen (got "
+                                + (screen == null ? "null" : screen.getClass().getName()) + ")");
+            }
+        });
+        ArmorHider.LOGGER.info("[smoke/fcgt] key press opens the settings screen");
+    }
+
+    /**
+     * The original user action: close the settings screen while the bound key is still physically held. On
+     * Windows/Linux the old code re-opened it here via {@code grabMouse() -> setAll()}.
+     */
+    private static void assertClosingDoesNotReopen(ClientGameTestContext context) {
+        final KeyMapping openSettings = resolveMapping(context, OpenSettingsKeyMapping.class);
+
+        context.getInput().holdKey(openSettings);
+        context.runOnClient(client -> {
+            Screen screen = currentScreen(client);
+            if (screen == null) {
+                throw new IllegalStateException("[smoke/fcgt] expected the settings screen to still be open");
+            }
+            screen.onClose();
+        });
+        context.waitTicks(10);
+        try {
+            context.runOnClient(client -> {
+                Screen screen = currentScreen(client);
+                if (screen != null) {
+                    throw new IllegalStateException(
+                            "[smoke/fcgt] a screen re-opened after closing the settings screen with the key held ("
+                                    + screen.getClass().getName() + ")");
+                }
+            });
+        } finally {
+            context.getInput().releaseKey(openSettings);
+        }
+        ArmorHider.LOGGER.info("[smoke/fcgt] closing with the key held does not re-open");
+    }
+
+    /** The toggle keybind still works through the press path. */
+    private static void assertToggleKeyFlipsSessionOverride(ClientGameTestContext context) {
+        boolean before = context.computeOnClient(client ->
+                ArmorHiderClient.CLIENT_CONFIG_MANAGER.hasSessionDisableOverride());
+
+        final KeyMapping toggle = resolveMapping(context, ToggleOffKeyMapping.class);
+        context.getInput().pressKey(toggle);
+        context.waitTicks(5);
+
+        boolean after = context.computeOnClient(client ->
+                ArmorHiderClient.CLIENT_CONFIG_MANAGER.hasSessionDisableOverride());
+        if (after == before) {
+            throw new IllegalStateException(
+                    "[smoke/fcgt] the toggle keybind did not flip the session disable override");
+        }
+
+        context.runOnClient(client -> ArmorHiderClient.CLIENT_CONFIG_MANAGER.clearSessionDisableOverride());
+        ArmorHider.LOGGER.info("[smoke/fcgt] toggle keybind flips the session override");
+    }
+
+    private static KeyMapping resolveMapping(ClientGameTestContext context,
+                                             Class<? extends CustomKeyMapping> type) {
+        return context.computeOnClient((Minecraft client) -> (KeyMapping) mapping(client, type));
+    }
+
+    private static <T extends CustomKeyMapping> T mapping(Minecraft client, Class<T> type) {
+        for (KeyMapping candidate : client.options.keyMappings) {
+            if (type.isInstance(candidate)) {
+                return type.cast(candidate);
+            }
+        }
+        throw new IllegalStateException("[smoke/fcgt] " + type.getSimpleName() + " is not registered");
+    }
+
+    private static @Nullable Screen currentScreen(Minecraft client) {
+        //? if <= 26.1.2
+        //return client.screen;
+        //? if > 26.1.2
+        return client.gui.screen();
+    }
+
+    private static void closeAnyScreen(Minecraft client) {
+        Screen screen = currentScreen(client);
+        if (screen != null) {
+            screen.onClose();
+        }
+        if (currentScreen(client) != null) {
+            throw new IllegalStateException("[smoke/fcgt] could not reach a screenless state");
+        }
+    }
+}
+//?}

--- a/common/src/main/java/de/zannagh/armorhider/configuration/ExclusionItemConfiguration.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/ExclusionItemConfiguration.java
@@ -47,10 +47,21 @@ public class ExclusionItemConfiguration {
      */
     public ExclusionItemConfiguration deepCopy() {
         var copy = new ExclusionItemConfiguration();
+        if (items == null) {
+            return copy;
+        }
+        // Null-tolerant: this is reached from ConfigPreset#applyTo/#fromPlayerConfig, whose exclusion map is
+        // read out of armor-hider-presets.json by plain Gson and never passes through PlayerConfig.heal().
         for (Map.Entry<String, Map<String, ExclusionItemInfo>> slotEntry : items.entrySet()) {
+            if (slotEntry.getKey() == null || slotEntry.getValue() == null) {
+                continue;
+            }
             var slotCopy = new LinkedHashMap<String, ExclusionItemInfo>();
             for (Map.Entry<String, ExclusionItemInfo> itemEntry : slotEntry.getValue().entrySet()) {
                 ExclusionItemInfo orig = itemEntry.getValue();
+                if (itemEntry.getKey() == null || orig == null) {
+                    continue;
+                }
                 slotCopy.put(itemEntry.getKey(), new ExclusionItemInfo(orig.displayName, orig.shouldIgnore));
             }
             copy.items.put(slotEntry.getKey(), slotCopy);
@@ -83,7 +94,13 @@ public class ExclusionItemConfiguration {
      * Returns all items configured for a given slot.
      */
     public Map<String, ExclusionItemInfo> getItemsForSlot(EquipmentSlot slot) {
-        return items.getOrDefault(slot.name(), Map.of());
+        if (items == null) {
+            return Map.of();
+        }
+        // getOrDefault returns a *stored* null rather than the fallback, so an explicit "HEAD": null in the
+        // JSON would otherwise hand callers a null map.
+        Map<String, ExclusionItemInfo> slotItems = items.get(slot.name());
+        return slotItems != null ? slotItems : Map.of();
     }
 
     /**
@@ -131,19 +148,37 @@ public class ExclusionItemConfiguration {
      * discovered entries first.
      */
     public synchronized int prune() {
+        // This map is deserialized reflectively by Gson — unlike ConfigurationItem fields it is NOT covered
+        // by ConfigurationSourceSerializer#initializeNullConfigFields — so explicit JSON nulls survive into
+        // it verbatim. Since prune() is the repair pass called from PlayerConfig.heal(), it must treat those
+        // nulls as more corruption to clean up rather than tripping over them: an NPE here propagates out of
+        // deserialize() into PlayerConfigFileProvider's catch-all, which discards the whole config and writes
+        // defaults — turning "heal the config" into "silently wipe the config".
         int removed = 0;
-        for (Map.Entry<String, Map<String, ExclusionItemInfo>> slotEntry : items.entrySet()) {
-            Map<String, ExclusionItemInfo> slotItems = slotEntry.getValue();
+        if (items == null) {
+            items = new LinkedHashMap<>();
+            return 0;
+        }
 
-            var syntheticKeys = new java.util.ArrayList<String>();
-            for (String key : slotItems.keySet()) {
-                if (key.startsWith(SYNTHETIC_ID_PREFIX)) {
-                    syntheticKeys.add(key);
-                }
-            }
-            for (String key : syntheticKeys) {
-                slotItems.remove(key);
+        var slotIterator = items.entrySet().iterator();
+        while (slotIterator.hasNext()) {
+            Map.Entry<String, Map<String, ExclusionItemInfo>> slotEntry = slotIterator.next();
+            Map<String, ExclusionItemInfo> slotItems = slotEntry.getValue();
+            if (slotEntry.getKey() == null || slotItems == null) {
+                slotIterator.remove();
                 removed++;
+                continue;
+            }
+
+            // Drop corrupt entries and synthetic identity-hash IDs in one pass.
+            var itemIterator = slotItems.entrySet().iterator();
+            while (itemIterator.hasNext()) {
+                Map.Entry<String, ExclusionItemInfo> itemEntry = itemIterator.next();
+                String itemId = itemEntry.getKey();
+                if (itemId == null || itemEntry.getValue() == null || itemId.startsWith(SYNTHETIC_ID_PREFIX)) {
+                    itemIterator.remove();
+                    removed++;
+                }
             }
 
             // Anything the user deliberately excluded is intent worth preserving, so only the passively

--- a/common/src/main/java/de/zannagh/armorhider/configuration/ExclusionItemConfiguration.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/ExclusionItemConfiguration.java
@@ -25,8 +25,14 @@ public class ExclusionItemConfiguration {
     /**
      * Slot name → item registry ID → exclusion info.
      * Uses String keys for both slot and item to ensure clean GSON serialization.
+     * <p>
+     * Declared as concrete {@link LinkedHashMap} at both levels on purpose: Gson honours a concrete field
+     * type and constructs {@code LinkedHashMap}s on deserialize, so iteration follows insertion (discovery)
+     * order that {@link #prune()} relies on. Left as the {@code Map} interface, Gson would instead build its
+     * own {@code LinkedTreeMap}; that happens to iterate in insertion order today, but pinning the type keeps
+     * the guarantee from silently depending on a Gson internal across the wide MC/Gson version range we build.
      */
-    Map<String, Map<String, ExclusionItemInfo>> items = new LinkedHashMap<>();
+    LinkedHashMap<String, LinkedHashMap<String, ExclusionItemInfo>> items = new LinkedHashMap<>();
 
     /**
      * Caches Item → registry ID lookups so that non-registry or slow lookups
@@ -52,7 +58,7 @@ public class ExclusionItemConfiguration {
         }
         // Null-tolerant: this is reached from ConfigPreset#applyTo/#fromPlayerConfig, whose exclusion map is
         // read out of armor-hider-presets.json by plain Gson and never passes through PlayerConfig.heal().
-        for (Map.Entry<String, Map<String, ExclusionItemInfo>> slotEntry : items.entrySet()) {
+        for (var slotEntry : items.entrySet()) {
             if (slotEntry.getKey() == null || slotEntry.getValue() == null) {
                 continue;
             }
@@ -82,12 +88,10 @@ public class ExclusionItemConfiguration {
      * Items not in the list default to NOT ignored (mod handles them).
      */
     public boolean shouldArmorHiderIgnore(EquipmentSlot slot, Item item) {
-        String itemId = getItemId(item);
-        Map<String, ExclusionItemInfo> slotItems = items.get(slot.name());
-        if (slotItems == null) return false;
-        ExclusionItemInfo info = slotItems.get(itemId);
-        if (info == null) return false;
-        return info.shouldIgnore;
+        // Routed through getItemsForSlot so it inherits the same null-safety: a corrupt "items": null (in a
+        // config or preset that has not yet been through prune()/heal()) must not NPE a render-path lookup.
+        ExclusionItemInfo info = getItemsForSlot(slot).get(getItemId(item));
+        return info != null && info.shouldIgnore;
     }
 
     /**
@@ -146,8 +150,9 @@ public class ExclusionItemConfiguration {
      *   <li><b>Unbounded discovery.</b> {@link #discoverItem} appends every equipped item ever rendered, for
      *       every player seen. On a busy modded server that is effectively unbounded.</li>
      * </ul>
-     * Insertion order is preserved by the backing {@link LinkedHashMap}, so trimming drops the oldest
-     * discovered entries first.
+     * The backing map is a {@link LinkedHashMap} at both levels (see the {@link #items} field note), so
+     * iteration follows insertion (discovery) order and trimming drops the oldest discovered entries first —
+     * and that holds across a save/reload, not just for a freshly-built instance.
      */
     public synchronized int prune() {
         // This map is deserialized reflectively by Gson — unlike ConfigurationItem fields it is NOT covered
@@ -167,7 +172,7 @@ public class ExclusionItemConfiguration {
 
         var slotIterator = items.entrySet().iterator();
         while (slotIterator.hasNext()) {
-            Map.Entry<String, Map<String, ExclusionItemInfo>> slotEntry = slotIterator.next();
+            var slotEntry = slotIterator.next();
             Map<String, ExclusionItemInfo> slotItems = slotEntry.getValue();
             if (slotEntry.getKey() == null || slotItems == null) {
                 slotIterator.remove();

--- a/common/src/main/java/de/zannagh/armorhider/configuration/ExclusionItemConfiguration.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/ExclusionItemConfiguration.java
@@ -106,6 +106,63 @@ public class ExclusionItemConfiguration {
         return info.shouldIgnore;
     }
 
+    /** Prefix of the synthetic IDs minted by {@link #getItemId} when a registry lookup fails. */
+    public static final String SYNTHETIC_ID_PREFIX = "unknown:";
+
+    /**
+     * Maximum number of discovered (non user-configured) entries retained per slot. Entries the user has
+     * explicitly excluded are always kept and do not count against this budget.
+     */
+    public static final int MAX_DISCOVERED_ITEMS_PER_SLOT = 512;
+
+    /**
+     * Drops entries that can never match again and bounds the rest, returning the number of entries removed.
+     * <p>
+     * Two problems are repaired here:
+     * <ul>
+     *   <li><b>Synthetic IDs.</b> {@link #getItemId} falls back to {@code "unknown:<class>_<identityHashCode>"}
+     *       for items missing from the registry. Identity hash codes are not stable across JVM runs, so every
+     *       launch mints fresh keys for the same items and the map grows without bound. None of these keys can
+     *       ever be matched again, so they are pure garbage.</li>
+     *   <li><b>Unbounded discovery.</b> {@link #discoverItem} appends every equipped item ever rendered, for
+     *       every player seen. On a busy modded server that is effectively unbounded.</li>
+     * </ul>
+     * Insertion order is preserved by the backing {@link LinkedHashMap}, so trimming drops the oldest
+     * discovered entries first.
+     */
+    public synchronized int prune() {
+        int removed = 0;
+        for (Map.Entry<String, Map<String, ExclusionItemInfo>> slotEntry : items.entrySet()) {
+            Map<String, ExclusionItemInfo> slotItems = slotEntry.getValue();
+
+            var syntheticKeys = new java.util.ArrayList<String>();
+            for (String key : slotItems.keySet()) {
+                if (key.startsWith(SYNTHETIC_ID_PREFIX)) {
+                    syntheticKeys.add(key);
+                }
+            }
+            for (String key : syntheticKeys) {
+                slotItems.remove(key);
+                removed++;
+            }
+
+            // Anything the user deliberately excluded is intent worth preserving, so only the passively
+            // discovered remainder is subject to the cap.
+            var discoveredKeys = new java.util.ArrayList<String>();
+            for (Map.Entry<String, ExclusionItemInfo> itemEntry : slotItems.entrySet()) {
+                if (!itemEntry.getValue().shouldIgnore) {
+                    discoveredKeys.add(itemEntry.getKey());
+                }
+            }
+            int excess = discoveredKeys.size() - MAX_DISCOVERED_ITEMS_PER_SLOT;
+            for (int i = 0; i < excess; i++) {
+                slotItems.remove(discoveredKeys.get(i));
+                removed++;
+            }
+        }
+        return removed;
+    }
+
     /**
      * If an item is not yet tracked for its slot, adds it with interception enabled.
      * Used for auto-discovery of new equippable items during rendering.
@@ -155,7 +212,7 @@ public class ExclusionItemConfiguration {
                 ArmorHider.LOGGER.warn("Failed to resolve registry ID for item {}: {}", i, e.getMessage());
             }
             // Fallback for items not in the registry
-            return "unknown:" + i.getClass().getSimpleName().toLowerCase() + "_" + System.identityHashCode(i);
+            return SYNTHETIC_ID_PREFIX + i.getClass().getSimpleName().toLowerCase() + "_" + System.identityHashCode(i);
         });
     }
 

--- a/common/src/main/java/de/zannagh/armorhider/configuration/ExclusionItemConfiguration.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/ExclusionItemConfiguration.java
@@ -133,7 +133,9 @@ public class ExclusionItemConfiguration {
     public static final int MAX_DISCOVERED_ITEMS_PER_SLOT = 512;
 
     /**
-     * Drops entries that can never match again and bounds the rest, returning the number of entries removed.
+     * Drops entries that can never match again and bounds the rest, returning the number of repairs made
+     * (entries removed, plus one if a null backing map had to be materialised) — a non-zero result signals
+     * the caller to persist the cleaned-up form.
      * <p>
      * Two problems are repaired here:
      * <ul>
@@ -157,7 +159,10 @@ public class ExclusionItemConfiguration {
         int removed = 0;
         if (items == null) {
             items = new LinkedHashMap<>();
-            return 0;
+            // Count the materialisation as a repair so the caller persists the fixed form. Returning 0 here
+            // would let an "items": null corruption be re-read and re-repaired on every launch, never written
+            // back, since PlayerConfig.heal() only flags the config dirty when prune() reports > 0.
+            return 1;
         }
 
         var slotIterator = items.entrySet().iterator();

--- a/common/src/main/java/de/zannagh/armorhider/configuration/PresetManager.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/PresetManager.java
@@ -71,7 +71,10 @@ public class PresetManager {
      * the render thread. Callers flush via {@link #flushPendingSave()} when the settings screen closes.
      */
     public void updateActivePreset(PlayerConfig config) {
-        if (activeIndex >= 0 && activeIndex < PRESET_COUNT && presets[activeIndex] != null) {
+        // Deliberately does NOT require presets[activeIndex] to be non-null: the preset is rebuilt wholesale
+        // from the live config, so a missing entry is something to materialise, not a reason to skip. Bailing
+        // out there would silently drop every settings change for as long as that slot stayed active.
+        if (activeIndex >= 0 && activeIndex < PRESET_COUNT) {
             presets[activeIndex] = ConfigPreset.fromPlayerConfig(config);
             pendingSave = true;
         }

--- a/common/src/main/java/de/zannagh/armorhider/configuration/PresetManager.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/PresetManager.java
@@ -5,7 +5,6 @@ import de.zannagh.armorhider.net.packets.PlayerConfig;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.file.Files;
@@ -127,7 +126,6 @@ public class PresetManager {
     }
 
     private void save() {
-        pendingSave = false;
         try {
             Path parent = file.getParent();
             if (parent != null) {
@@ -139,7 +137,10 @@ public class PresetManager {
                 storage.activeIndex = activeIndex;
                 ArmorHider.GSON.toJson(storage, w);
             }
-        } catch (IOException e) {
+            // Cleared only after the write actually succeeds: clearing up front would make a failed save
+            // silently discard the pending edits, since flushPendingSave() would never retry them.
+            pendingSave = false;
+        } catch (Exception e) {
             ArmorHider.LOGGER.error("Failed to save presets!", e);
         }
     }

--- a/common/src/main/java/de/zannagh/armorhider/configuration/PresetManager.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/PresetManager.java
@@ -19,6 +19,8 @@ public class PresetManager {
     private final Path file;
     private final ConfigPreset @Nullable [] presets = new ConfigPreset[PRESET_COUNT];
     private int activeIndex = -1;
+    /** Set by {@link #updateActivePreset}; cleared by {@link #save()}. See {@link #flushPendingSave()}. */
+    private boolean pendingSave;
 
     public PresetManager() {
         this(DEFAULT_FILE);
@@ -62,9 +64,23 @@ public class PresetManager {
         savePreset(index, ConfigPreset.fromPlayerConfig(config));
     }
 
+    /**
+     * Syncs the live config into the active preset <em>in memory only</em>, marking it for a later write.
+     * <p>
+     * This is called from every settings mutation, including slider movement. Writing here is what made a
+     * single slider drag issue a synchronous, pretty-printed serialization of all five presets per frame on
+     * the render thread. Callers flush via {@link #flushPendingSave()} when the settings screen closes.
+     */
     public void updateActivePreset(PlayerConfig config) {
         if (activeIndex >= 0 && activeIndex < PRESET_COUNT && presets[activeIndex] != null) {
             presets[activeIndex] = ConfigPreset.fromPlayerConfig(config);
+            pendingSave = true;
+        }
+    }
+
+    /** Writes presets to disk if {@link #updateActivePreset} left changes pending. */
+    public void flushPendingSave() {
+        if (pendingSave) {
             save();
         }
     }
@@ -111,6 +127,7 @@ public class PresetManager {
     }
 
     private void save() {
+        pendingSave = false;
         try {
             Path parent = file.getParent();
             if (parent != null) {

--- a/common/src/main/java/de/zannagh/armorhider/configuration/abstractions/ConfigurationItemBase.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/abstractions/ConfigurationItemBase.java
@@ -12,7 +12,7 @@ public abstract class ConfigurationItemBase<T> {
     protected T value;
 
     public ConfigurationItemBase(T actualValue) {
-        this.value = actualValue;
+        this.value = sanitize(actualValue);
     }
 
     public ConfigurationItemBase() {
@@ -24,11 +24,20 @@ public abstract class ConfigurationItemBase<T> {
     }
 
     public void setValue(T value) {
-        if (value == null) {
-            this.value = getDefaultValue();
-            return;
-        }
-        this.value = value;
+        this.value = sanitize(value);
+    }
+
+    /**
+     * Normalises a candidate value before it is stored. The base contract is only "null becomes the default";
+     * subclasses narrow it further (e.g. clamping a range).
+     * <p>
+     * This must be applied by the value constructor as well as {@link #setValue}, because the Gson read path
+     * ({@code ConfigurationItemSerializer.ConfigurationItemTypeAdapter#read}) instantiates items through the
+     * single-argument constructor and never calls {@code setValue} — so a check placed only in the setter
+     * would let a corrupt on-disk or on-wire value through untouched.
+     */
+    protected T sanitize(T candidate) {
+        return candidate == null ? getDefaultValue() : candidate;
     }
 
     public abstract T getDefaultValue();

--- a/common/src/main/java/de/zannagh/armorhider/configuration/abstractions/DoubleConfigurationItem.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/abstractions/DoubleConfigurationItem.java
@@ -29,4 +29,29 @@ public abstract class DoubleConfigurationItem extends ConfigurationItemBase<Doub
     public DoubleConfigurationItem() {
         super();
     }
+
+    /** Lower bound, inclusive. Unbounded by default; range-limited items override it. */
+    protected double getMinValue() {
+        return Double.NEGATIVE_INFINITY;
+    }
+
+    /** Upper bound, inclusive. Unbounded by default; range-limited items override it. */
+    protected double getMaxValue() {
+        return Double.POSITIVE_INFINITY;
+    }
+
+    /**
+     * Rejects non-finite values (NaN / ±Infinity) outright and clamps everything else into
+     * {@code [getMinValue(), getMaxValue()]}. NaN in particular has to be caught here: it round-trips
+     * through the config item happily but makes {@code Gson#toJson} throw {@link IllegalArgumentException},
+     * which escapes the IOException-only catch in the save path and can leave a settings screen unclosable.
+     */
+    @Override
+    protected Double sanitize(Double candidate) {
+        if (candidate == null || !Double.isFinite(candidate)) {
+            return getDefaultValue();
+        }
+        // Math.clamp is Java 21+; 1.20.1 builds on Java 17.
+        return Math.min(Math.max(candidate, getMinValue()), getMaxValue());
+    }
 }

--- a/common/src/main/java/de/zannagh/armorhider/configuration/items/ArmorOpacity.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/items/ArmorOpacity.java
@@ -31,4 +31,14 @@ public class ArmorOpacity extends DoubleConfigurationItem {
     public Double getDefaultValue() {
         return DEFAULT_OPACITY;
     }
+
+    @Override
+    protected double getMinValue() {
+        return 0.0;
+    }
+
+    @Override
+    protected double getMaxValue() {
+        return 1.0;
+    }
 }

--- a/common/src/main/java/de/zannagh/armorhider/configuration/items/OffHandOpacity.java
+++ b/common/src/main/java/de/zannagh/armorhider/configuration/items/OffHandOpacity.java
@@ -23,4 +23,14 @@ public class OffHandOpacity extends DoubleConfigurationItem {
     public Double getDefaultValue() {
         return DEFAULT_OPACITY;
     }
+
+    @Override
+    protected double getMinValue() {
+        return 0.0;
+    }
+
+    @Override
+    protected double getMaxValue() {
+        return 1.0;
+    }
 }

--- a/common/src/main/java/de/zannagh/armorhider/net/CompressedJsonCodec.java
+++ b/common/src/main/java/de/zannagh/armorhider/net/CompressedJsonCodec.java
@@ -8,6 +8,9 @@ import net.minecraft.network.codec.StreamCodec;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
@@ -40,6 +43,14 @@ public class CompressedJsonCodec {
      * A little headroom is kept for the length prefix and framing.
      */
     public static final int MAX_SERVERBOUND_PAYLOAD_BYTES = 32767 - 256;
+
+    /**
+     * Ceiling on the <em>inflated</em> size of a decoded payload, guarding against a decompression bomb on
+     * what is an attacker-controlled stream. Sized against real data: a 1500-player {@code ServerConfiguration}
+     * measures ~14.8 MiB uncompressed (~38x compression), so 64 MiB leaves a comfortable 4x margin for
+     * legitimately huge servers while still bounding memory use during parsing.
+     */
+    public static final int MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
 
     private static <T> void encode(ByteBuf byteBuf, T value) {
         try {
@@ -79,8 +90,12 @@ public class CompressedJsonCodec {
             buf.readBytes(compressed);
 
             ByteArrayInputStream byteStream = new ByteArrayInputStream(compressed);
+            // Bounding the compressed length is not enough on its own: gzip routinely hits ~38x on this data
+            // (measured) and a crafted stream reaches ~1000x, so a 1 MiB payload could otherwise inflate to
+            // hundreds of megabytes during parsing. Cap the inflated side too.
             try (GZIPInputStream gzipStream = new GZIPInputStream(byteStream);
-                 InputStreamReader reader = new InputStreamReader(gzipStream, StandardCharsets.UTF_8)) {
+                 InputStream boundedStream = new SizeLimitedInputStream(gzipStream, MAX_DECOMPRESSED_BYTES);
+                 InputStreamReader reader = new InputStreamReader(boundedStream, StandardCharsets.UTF_8)) {
                 T decoded = ArmorHider.GSON.fromJson(reader, clazz);
                 // Configs arriving off the wire get the same repair pass as configs read from disk —
                 // PlayerConfig.deserialize is bypassed entirely on this path.
@@ -91,6 +106,55 @@ public class CompressedJsonCodec {
             }
         } catch (Exception e) {
             throw new RuntimeException("Failed to decode compressed JSON", e);
+        }
+    }
+
+    /**
+     * Fails fast once more than {@code limit} bytes have been read, so an over-large stream is rejected
+     * during inflation rather than after it has already been materialised in memory.
+     */
+    private static final class SizeLimitedInputStream extends FilterInputStream {
+
+        private final long limit;
+        private long consumed;
+
+        private SizeLimitedInputStream(InputStream delegate, long limit) {
+            super(delegate);
+            this.limit = limit;
+        }
+
+        private void recordRead(long readCount) throws IOException {
+            if (readCount <= 0) {
+                return;
+            }
+            consumed += readCount;
+            if (consumed > limit) {
+                throw new IOException("Rejecting an armor-hider payload that inflates beyond " + limit
+                        + " bytes — refusing to decompress further");
+            }
+        }
+
+        @Override
+        public int read() throws IOException {
+            int value = super.read();
+            if (value != -1) {
+                recordRead(1);
+            }
+            return value;
+        }
+
+        @Override
+        public int read(byte[] buffer, int off, int len) throws IOException {
+            int readCount = super.read(buffer, off, len);
+            recordRead(readCount);
+            return readCount;
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            long skipped = super.skip(n);
+            recordRead(skipped);
+            return skipped;
         }
     }
 

--- a/common/src/main/java/de/zannagh/armorhider/net/CompressedJsonCodec.java
+++ b/common/src/main/java/de/zannagh/armorhider/net/CompressedJsonCodec.java
@@ -26,6 +26,21 @@ public class CompressedJsonCodec {
     }
     //?}
 
+    /**
+     * Vanilla's clientbound custom-payload ceiling ({@code ClientboundCustomPayloadPacket.MAX_PAYLOAD_SIZE},
+     * 1 MiB). Used as the upper sanity bound for any payload we encode or decode.
+     */
+    public static final int MAX_PAYLOAD_BYTES = 1048576;
+
+    /**
+     * Vanilla's <em>serverbound</em> ceiling ({@code ServerboundCustomPayloadPacket.MAX_PAYLOAD_SIZE}) is far
+     * tighter at 32767, and a vanilla server — Realms included — decodes unknown payloads via
+     * {@code DiscardedPayload}, which throws and disconnects the client for anything larger. Only C2S types
+     * are held to this limit; the S2C {@code ServerConfiguration} broadcast legitimately runs much larger.
+     * A little headroom is kept for the length prefix and framing.
+     */
+    public static final int MAX_SERVERBOUND_PAYLOAD_BYTES = 32767 - 256;
+
     private static <T> void encode(ByteBuf byteBuf, T value) {
         try {
             ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
@@ -35,6 +50,16 @@ public class CompressedJsonCodec {
             }
 
             byte[] compressed = byteStream.toByteArray();
+            // PlayerConfig is our only sizeable C2S payload, so it is the one held to the serverbound limit.
+            // Refusing here beats letting a vanilla server kick the client on join. Backstop only: the
+            // payload should no longer be able to get this big now that forNetwork() drops the exclusion map.
+            int limit = value instanceof de.zannagh.armorhider.net.packets.PlayerConfig
+                    ? MAX_SERVERBOUND_PAYLOAD_BYTES
+                    : MAX_PAYLOAD_BYTES;
+            if (compressed.length > limit) {
+                throw new IllegalStateException("Refusing to encode an oversized armor-hider payload: "
+                        + compressed.length + " bytes exceeds the " + limit + " byte limit");
+            }
             byteBuf.writeInt(compressed.length);
             byteBuf.writeBytes(compressed);
         } catch (Exception e) {
@@ -45,13 +70,24 @@ public class CompressedJsonCodec {
     private static <T> T decode(ByteBuf buf, Class<T> clazz) {
         try {
             int length = buf.readInt();
+            // The length prefix is attacker-controlled; allocating on it unchecked is a trivial OOM.
+            if (length < 0 || length > MAX_PAYLOAD_BYTES || length > buf.readableBytes()) {
+                throw new IllegalArgumentException("Rejecting an armor-hider payload with an implausible "
+                        + "length of " + length + " bytes (" + buf.readableBytes() + " readable)");
+            }
             byte[] compressed = new byte[length];
             buf.readBytes(compressed);
 
             ByteArrayInputStream byteStream = new ByteArrayInputStream(compressed);
             try (GZIPInputStream gzipStream = new GZIPInputStream(byteStream);
                  InputStreamReader reader = new InputStreamReader(gzipStream, StandardCharsets.UTF_8)) {
-                return ArmorHider.GSON.fromJson(reader, clazz);
+                T decoded = ArmorHider.GSON.fromJson(reader, clazz);
+                // Configs arriving off the wire get the same repair pass as configs read from disk —
+                // PlayerConfig.deserialize is bypassed entirely on this path.
+                if (decoded instanceof de.zannagh.armorhider.net.packets.PlayerConfig playerConfig) {
+                    de.zannagh.armorhider.net.packets.PlayerConfig.heal(playerConfig);
+                }
+                return decoded;
             }
         } catch (Exception e) {
             throw new RuntimeException("Failed to decode compressed JSON", e);

--- a/common/src/main/java/de/zannagh/armorhider/net/packets/PlayerConfig.java
+++ b/common/src/main/java/de/zannagh/armorhider/net/packets/PlayerConfig.java
@@ -41,7 +41,15 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
     public int configVersion;
 
     /** The current config schema version. */
-    public static final int CURRENT_CONFIG_VERSION = 11;
+    public static final int CURRENT_CONFIG_VERSION = 12;
+
+    /**
+     * Maximum nesting depth for {@link #globalPlayerOverride}. The override is itself a {@link PlayerConfig},
+     * so the structure is recursive; exactly one level is meaningful and anything deeper is corruption. A
+     * cycle here makes {@code Gson#toJson} blow the stack, which escapes the IOException-only catch in the
+     * save path, so {@link #heal} flattens it rather than trusting the data.
+     */
+    private static final int MAX_GLOBAL_OVERRIDE_DEPTH = 1;
 
     //? if >= 1.21.11 {
     public static final Identifier PACKET_IDENTIFIER = Identifier.fromNamespaceAndPath("de.zannagh.armorhider", "settings_c2s_packet");
@@ -377,11 +385,68 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
     }
 
     public static PlayerConfig deserialize(Reader reader) {
-        return ArmorHider.GSON.fromJson(reader, PlayerConfig.class);
+        return heal(ArmorHider.GSON.fromJson(reader, PlayerConfig.class));
     }
 
     public static PlayerConfig deserialize(String content) {
-        return ArmorHider.GSON.fromJson(content, PlayerConfig.class);
+        return heal(ArmorHider.GSON.fromJson(content, PlayerConfig.class));
+    }
+
+    /**
+     * Repairs a freshly-deserialized config in place and returns it.
+     * <p>
+     * This is deliberately <em>separate from and independent of</em> {@link #migrate}. Migration only runs
+     * when {@code configVersion < CURRENT_CONFIG_VERSION}, so a config that is already at the current version
+     * but has been corrupted at runtime would otherwise be loaded and used verbatim — which is exactly how a
+     * config that grew a multi-megabyte exclusion map, or a non-finite opacity, survives a restart and even a
+     * reinstall of the mod. Healing therefore runs unconditionally on every deserialize, from disk and from
+     * the network alike.
+     * <p>
+     * Opacity clamping is not done here: it lives in {@code DoubleConfigurationItem#sanitize}, which the Gson
+     * read path already applies through the single-argument constructor.
+     *
+     * @return the same instance, repaired; {@code null} in, {@code null} out
+     */
+    public static @org.jetbrains.annotations.Nullable PlayerConfig heal(
+            @org.jetbrains.annotations.Nullable PlayerConfig config) {
+        return heal(config, 0);
+    }
+
+    private static @org.jetbrains.annotations.Nullable PlayerConfig heal(
+            @org.jetbrains.annotations.Nullable PlayerConfig config, int depth) {
+        if (config == null) {
+            return null;
+        }
+
+        if (config.exclusionItems == null) {
+            config.exclusionItems = ExclusionItemConfiguration.defaults();
+            config.setHasChangedFromSerializedContent();
+        } else {
+            int pruned = config.exclusionItems.prune();
+            if (pruned > 0) {
+                ArmorHider.LOGGER.info("Pruned {} stale exclusion-item entries from the config for {}.",
+                        pruned, config.playerName.getValue());
+                config.setHasChangedFromSerializedContent();
+            }
+        }
+
+        if (config.globalPlayerOverride != null) {
+            if (depth >= MAX_GLOBAL_OVERRIDE_DEPTH) {
+                ArmorHider.LOGGER.warn(
+                        "Dropping a global player override nested {} levels deep in the config for {} — "
+                                + "only one level is meaningful and deeper nesting corrupts serialization.",
+                        depth + 1, config.playerName.getValue());
+                config.globalPlayerOverride = null;
+                config.setHasChangedFromSerializedContent();
+            } else {
+                heal(config.globalPlayerOverride, depth + 1);
+                if (config.globalPlayerOverride.hasChangedFromSerializedContent()) {
+                    config.setHasChangedFromSerializedContent();
+                }
+            }
+        }
+
+        return config;
     }
 
     @Contract("-> new")
@@ -489,9 +554,16 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
      * state: {@link #individualConfigurations}, the {@link #useGlobalOverrideForAllPlayers} flag and the
      * {@link #globalPlayerOverride}. Those are a purely client-side concern and must never be broadcast to
      * the server or other players. ({@link #deepCopy} copies none of them, so this delegates straight to it.)
+     * <p>
+     * {@link #exclusionItems} is also dropped: which items the mod skips is a purely client-side render
+     * decision that nothing server-side reads, while the map is the one unbounded part of the config. Left
+     * in, a large map pushes the gzipped payload past the vanilla 32767-byte custom-payload limit, and a
+     * vanilla server (Realms included) responds by disconnecting the client on join.
      */
     public PlayerConfig forNetwork() {
-        return deepCopy(playerName.getValue(), playerId.getValue());
+        var networkConfig = deepCopy(playerName.getValue(), playerId.getValue());
+        networkConfig.exclusionItems = ExclusionItemConfiguration.defaults();
+        return networkConfig;
     }
 
     public PlayerConfig deepCopy(String playerName, UUID playerId) {

--- a/common/src/main/java/de/zannagh/armorhider/net/packets/PlayerConfig.java
+++ b/common/src/main/java/de/zannagh/armorhider/net/packets/PlayerConfig.java
@@ -418,6 +418,12 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
             return null;
         }
 
+        // Identity fields are only read for log context, and are resolved defensively: healing must never be
+        // the thing that throws. In practice ConfigurationSourceSerializer#initializeNullConfigFields has
+        // already backfilled any null ConfigurationItem field by the time we get here (verified by test), but
+        // heal() is also callable on hand-built instances, where that guarantee does not hold.
+        String owner = describeOwner(config);
+
         if (config.exclusionItems == null) {
             config.exclusionItems = ExclusionItemConfiguration.defaults();
             config.setHasChangedFromSerializedContent();
@@ -425,7 +431,7 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
             int pruned = config.exclusionItems.prune();
             if (pruned > 0) {
                 ArmorHider.LOGGER.info("Pruned {} stale exclusion-item entries from the config for {}.",
-                        pruned, config.playerName.getValue());
+                        pruned, owner);
                 config.setHasChangedFromSerializedContent();
             }
         }
@@ -435,7 +441,7 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
                 ArmorHider.LOGGER.warn(
                         "Dropping a global player override nested {} levels deep in the config for {} — "
                                 + "only one level is meaningful and deeper nesting corrupts serialization.",
-                        depth + 1, config.playerName.getValue());
+                        depth + 1, owner);
                 config.globalPlayerOverride = null;
                 config.setHasChangedFromSerializedContent();
             } else {
@@ -447,6 +453,17 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
         }
 
         return config;
+    }
+
+    /** Log-context helper for {@link #heal}; never throws, whatever state the config is in. */
+    private static String describeOwner(PlayerConfig config) {
+        try {
+            return config.playerName != null && config.playerName.getValue() != null
+                    ? config.playerName.getValue()
+                    : "<unknown>";
+        } catch (Exception e) {
+            return "<unknown>";
+        }
     }
 
     @Contract("-> new")
@@ -559,10 +576,16 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
      * decision that nothing server-side reads, while the map is the one unbounded part of the config. Left
      * in, a large map pushes the gzipped payload past the vanilla 32767-byte custom-payload limit, and a
      * vanilla server (Realms included) responds by disconnecting the client on join.
+     * <p>
+     * The map is sent <em>empty</em> rather than seeded with {@link ExclusionItemConfiguration#defaults()}:
+     * every default entry is {@code intercepted} (i.e. {@code shouldIgnore == false}), and
+     * {@link ExclusionItemConfiguration#shouldArmorHiderIgnore} also returns {@code false} for an absent
+     * entry — so the two are behaviourally identical for any reader, and empty is a few dozen entries
+     * smaller on the wire.
      */
     public PlayerConfig forNetwork() {
         var networkConfig = deepCopy(playerName.getValue(), playerId.getValue());
-        networkConfig.exclusionItems = ExclusionItemConfiguration.defaults();
+        networkConfig.exclusionItems = new ExclusionItemConfiguration();
         return networkConfig;
     }
 

--- a/common/src/main/java/de/zannagh/armorhider/net/packets/PlayerConfig.java
+++ b/common/src/main/java/de/zannagh/armorhider/net/packets/PlayerConfig.java
@@ -430,13 +430,19 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
         } else {
             int pruned = config.exclusionItems.prune();
             if (pruned > 0) {
-                ArmorHider.LOGGER.info("Pruned {} stale exclusion-item entries from the config for {}.",
+                ArmorHider.LOGGER.info("Repaired {} corrupt or stale exclusion-item entries in the config for {}.",
                         pruned, owner);
                 config.setHasChangedFromSerializedContent();
             }
         }
 
-        if (config.globalPlayerOverride != null) {
+        // Capture the override in a local before recursing. If the structure is self-referential
+        // (override == config, only reachable via programmatic construction, not JSON), the recursive call
+        // hits the depth limit and sets config.globalPlayerOverride = null on the shared instance — which
+        // would null this very field. Reading the captured local instead of config.globalPlayerOverride keeps
+        // the follow-up dereference safe, honouring the rule that healing must never itself throw.
+        PlayerConfig override = config.globalPlayerOverride;
+        if (override != null) {
             if (depth >= MAX_GLOBAL_OVERRIDE_DEPTH) {
                 ArmorHider.LOGGER.warn(
                         "Dropping a global player override nested {} levels deep in the config for {} — "
@@ -445,8 +451,8 @@ public class PlayerConfig implements ConfigurationSource<PlayerConfig> {
                 config.globalPlayerOverride = null;
                 config.setHasChangedFromSerializedContent();
             } else {
-                heal(config.globalPlayerOverride, depth + 1);
-                if (config.globalPlayerOverride.hasChangedFromSerializedContent()) {
+                heal(override, depth + 1);
+                if (override.hasChangedFromSerializedContent()) {
                     config.setHasChangedFromSerializedContent();
                 }
             }

--- a/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
+++ b/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
@@ -2,6 +2,8 @@ package de.zannagh.armorhider;
 
 import de.zannagh.armorhider.client.api.impl.AhPlayerConfigApiImpl;
 import de.zannagh.armorhider.configuration.ConfigurationItemFactoryRegistry;
+import de.zannagh.armorhider.configuration.ExclusionItemConfiguration;
+import de.zannagh.armorhider.net.CompressedJsonCodec;
 import de.zannagh.armorhider.configuration.items.ArmorOpacity;
 import de.zannagh.armorhider.net.packets.PlayerConfig;
 import org.junit.jupiter.api.BeforeAll;
@@ -447,5 +449,148 @@ class PlayerConfigurationTests {
         assertEquals(UUID.fromString("6f7d35ad-9152-3823-9277-b683a91158a3"), currentConfig.playerId.getValue());
         assertEquals("Player446", currentConfig.playerName.getValue());
         assertEquals(true, currentConfig.enableCombatDetection.getValue());
+    }
+
+    // ── Config healing (schema v12) ──────────────────────────────────────────────────────────────
+    // These cover the corruption that survives a restart AND a mod reinstall, because it lives in
+    // config/armor-hider.json rather than in the mod. Healing runs on every deserialize, NOT only when
+    // the version is stale — a config already at the current version can still be corrupt.
+
+    @Test
+    @DisplayName("Opacity above the valid range is clamped when read from disk")
+    void healClampsOpacityAboveRange() {
+        var config = PlayerConfig.deserialize("{\"configVersion\": 12, \"helmetOpacity\": 5.0}");
+        assertEquals(1.0, config.helmetOpacity.getValue(),
+                "opacity must clamp to 1.0; the Gson read path uses the value constructor, not setValue");
+    }
+
+    @Test
+    @DisplayName("Negative opacity is clamped when read from disk")
+    void healClampsNegativeOpacity() {
+        var config = PlayerConfig.deserialize("{\"configVersion\": 12, \"chestOpacity\": -3.0}");
+        assertEquals(0.0, config.chestOpacity.getValue());
+    }
+
+    @Test
+    @DisplayName("Non-finite opacity falls back to the default and stays serializable")
+    void healRejectsNonFiniteOpacity() {
+        // Bare NaN/Infinity are not legal JSON, so they cannot arrive through the parser. They reach a config
+        // item through the single-argument constructor — which is exactly the path the Gson type adapter uses
+        // — or through arithmetic on a value. Either way the danger is the same: Gson#toJson throws
+        // IllegalArgumentException on a non-finite double, which escapes the IOException-only catch in the
+        // save path and can leave the settings screen unclosable.
+        var config = PlayerConfig.defaults(UUID.randomUUID(), "Corrupt");
+        config.legsOpacity = new ArmorOpacity(Double.NaN);
+        assertEquals(ArmorOpacity.DEFAULT_OPACITY, config.legsOpacity.getValue(),
+                "the value constructor must reject NaN, since the Gson read path never calls setValue");
+        assertEquals(ArmorOpacity.DEFAULT_OPACITY, new ArmorOpacity(Double.POSITIVE_INFINITY).getValue());
+        assertDoesNotThrow(config::toJson, "a healed config must always be serializable");
+    }
+
+    @Test
+    @DisplayName("Setting an opacity out of range clamps it too")
+    void setValueClampsOpacity() {
+        var opacity = new ArmorOpacity();
+        opacity.setValue(42.0);
+        assertEquals(1.0, opacity.getValue());
+        opacity.setValue(Double.NEGATIVE_INFINITY);
+        assertEquals(ArmorOpacity.DEFAULT_OPACITY, opacity.getValue());
+    }
+
+    @Test
+    @DisplayName("Healing strips synthetic unknown: exclusion IDs, which can never match again")
+    void healPrunesSyntheticExclusionIds() {
+        String json = """
+                {
+                  "configVersion": 12,
+                  "exclusionItems": {
+                    "items": {
+                      "HEAD": {
+                        "minecraft:iron_helmet": {"displayName": "Iron Helmet", "shouldIgnore": false},
+                        "unknown:someitem_12345": {"displayName": "Mystery", "shouldIgnore": false},
+                        "unknown:someitem_67890": {"displayName": "Mystery", "shouldIgnore": false}
+                      }
+                    }
+                  }
+                }
+                """;
+        var config = PlayerConfig.deserialize(json);
+        var head = config.getExclusionItems()
+                .getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.HEAD);
+        assertTrue(head.containsKey("minecraft:iron_helmet"), "real registry IDs must be kept");
+        assertEquals(1, head.size(), "synthetic identity-hash IDs must be dropped");
+        assertTrue(config.hasChangedFromSerializedContent(),
+                "pruning must mark the config dirty so the repaired form is written back");
+    }
+
+    @Test
+    @DisplayName("Healing caps discovered exclusion entries but keeps user-excluded ones")
+    void healCapsDiscoveredExclusionsButKeepsUserIntent() {
+        var config = PlayerConfig.defaults(UUID.randomUUID(), "Hoarder");
+        var exclusions = config.getExclusionItems();
+        int overCap = ExclusionItemConfiguration.MAX_DISCOVERED_ITEMS_PER_SLOT + 50;
+        for (int i = 0; i < overCap; i++) {
+            exclusions.setItem(net.minecraft.world.entity.EquipmentSlot.HEAD, "testmod:helmet_" + i,
+                    de.zannagh.armorhider.configuration.ExclusionItemInfo.intercepted("Helmet " + i));
+        }
+        exclusions.setItem(net.minecraft.world.entity.EquipmentSlot.HEAD, "testmod:user_excluded",
+                de.zannagh.armorhider.configuration.ExclusionItemInfo.ignored("Deliberately excluded"));
+
+        exclusions.prune();
+
+        var head = exclusions.getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.HEAD);
+        assertTrue(head.containsKey("testmod:user_excluded"),
+                "an entry the user deliberately excluded must never be pruned away");
+        assertTrue(head.size() <= ExclusionItemConfiguration.MAX_DISCOVERED_ITEMS_PER_SLOT + 1,
+                "discovered entries must be capped, got " + head.size());
+        assertFalse(head.containsKey("testmod:helmet_0"), "the oldest discovered entries are dropped first");
+    }
+
+    @Test
+    @DisplayName("Healing flattens a recursively nested global override")
+    void healFlattensNestedGlobalOverride() {
+        var config = PlayerConfig.defaults(UUID.randomUUID(), "Viewer");
+        config.globalPlayerOverride = PlayerConfig.defaults(UUID.randomUUID(), "Global");
+        config.globalPlayerOverride.globalPlayerOverride =
+                PlayerConfig.defaults(UUID.randomUUID(), "TooDeep");
+
+        PlayerConfig.heal(config);
+
+        assertNotNull(config.globalPlayerOverride, "one level of override is legitimate and must be kept");
+        assertNull(config.globalPlayerOverride.globalPlayerOverride,
+                "deeper nesting is corruption and must be dropped before it can break serialization");
+    }
+
+    @Test
+    @DisplayName("forNetwork drops the exclusion map so the C2S payload stays under the vanilla limit")
+    void forNetworkDropsExclusionItems() {
+        var config = PlayerConfig.defaults(UUID.randomUUID(), "Sender");
+        var exclusions = config.getExclusionItems();
+        for (int i = 0; i < 2000; i++) {
+            exclusions.setItem(net.minecraft.world.entity.EquipmentSlot.CHEST, "testmod:plate_" + i,
+                    de.zannagh.armorhider.configuration.ExclusionItemInfo.intercepted("Plate number " + i));
+        }
+
+        var network = config.forNetwork();
+        assertFalse(network.getExclusionItems()
+                        .getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.CHEST)
+                        .containsKey("testmod:plate_0"),
+                "the client-only exclusion map must not be broadcast");
+
+        int encodedSize = network.toJson().getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+        assertTrue(encodedSize < CompressedJsonCodec.MAX_SERVERBOUND_PAYLOAD_BYTES,
+                "even uncompressed, the network config must sit well under the 32767-byte serverbound limit, got "
+                        + encodedSize);
+    }
+
+    @Test
+    @DisplayName("A config already at the current version is still healed")
+    void healRunsEvenWhenVersionIsCurrent() {
+        String json = "{\"configVersion\": " + PlayerConfig.CURRENT_CONFIG_VERSION
+                + ", \"bootsOpacity\": 99.0}";
+        var config = PlayerConfig.deserialize(json);
+        assertFalse(config.shouldMigrate(), "precondition: this config must not qualify for migration");
+        assertEquals(1.0, config.bootsOpacity.getValue(),
+                "healing must not be gated on the schema version — that is why the reporter's config survived a reinstall");
     }
 }

--- a/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
+++ b/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
@@ -632,6 +632,37 @@ class PlayerConfigurationTests {
     }
 
     @Test
+    @DisplayName("Discovery order survives a save/reload, so prune still drops oldest-first")
+    void exclusionPruneKeepsDiscoveryOrderAcrossReload() {
+        // Insert discovered keys in DESCENDING numeric order, so insertion (discovery) order and sorted order
+        // disagree: discovery-first is "k511", sorted-first is "k000". If the map deserialized as a sorted
+        // structure, prune would drop "k000"; if discovery order is preserved, it drops "k511".
+        var original = new ExclusionItemConfiguration();
+        int count = ExclusionItemConfiguration.MAX_DISCOVERED_ITEMS_PER_SLOT + 1; // one over the cap
+        for (int i = count - 1; i >= 0; i--) {
+            original.setItem(net.minecraft.world.entity.EquipmentSlot.HEAD,
+                    String.format("testmod:k%03d", i),
+                    de.zannagh.armorhider.configuration.ExclusionItemInfo.intercepted("k" + i));
+        }
+
+        // Round-trip through JSON exactly as a real config would on save + next launch.
+        var reloaded = ExclusionItemConfiguration.deserialize(
+                de.zannagh.armorhider.ArmorHider.GSON.toJson(original));
+
+        var beforePrune = new java.util.ArrayList<>(
+                reloaded.getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.HEAD).keySet());
+        assertEquals("testmod:k512", beforePrune.get(0),
+                "the first-discovered key must still iterate first after a reload (insertion order, not sorted)");
+
+        reloaded.prune();
+
+        var head = reloaded.getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.HEAD);
+        assertEquals(ExclusionItemConfiguration.MAX_DISCOVERED_ITEMS_PER_SLOT, head.size());
+        assertFalse(head.containsKey("testmod:k512"), "the oldest-discovered entry must be the one dropped");
+        assertTrue(head.containsKey("testmod:k000"), "the newest-discovered entry must be kept");
+    }
+
+    @Test
     @DisplayName("Healing a self-referential global override does not throw")
     void healToleratesSelfReferentialGlobalOverride() {
         // Not reachable from JSON (a tree), but heal() is public API and callable on programmatically-built

--- a/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
+++ b/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
@@ -584,6 +584,51 @@ class PlayerConfigurationTests {
     }
 
     @Test
+    @DisplayName("forNetwork sends an empty exclusion map, not the seeded defaults")
+    void forNetworkSendsEmptyExclusionMap() {
+        var config = PlayerConfig.defaults(UUID.randomUUID(), "Sender");
+        var network = config.forNetwork();
+        for (var slot : net.minecraft.world.entity.EquipmentSlot.values()) {
+            assertTrue(network.getExclusionItems().getItemsForSlot(slot).isEmpty(),
+                    "slot " + slot + " should carry no exclusion entries over the wire");
+        }
+        // Behaviourally identical to sending ExclusionItemConfiguration.defaults(): every default entry is
+        // `intercepted` (shouldIgnore == false), and shouldArmorHiderIgnore also returns false for an absent
+        // entry — so an empty map resolves the same way for every reader while being smaller on the wire.
+        // (Not asserted through shouldArmorHiderIgnore directly: that needs an Item instance, and touching
+        // net.minecraft.world.item.Items requires the MC registry bootstrap these unit tests do not run.)
+    }
+
+    @Test
+    @DisplayName("A failed preset save stays pending and is retried by the next flush")
+    void failedPresetSaveIsRetried(@org.junit.jupiter.api.io.TempDir java.nio.file.Path tempDir)
+            throws Exception {
+        // Block the parent directory with a regular file so Files.createDirectories fails and save() throws.
+        var blocker = tempDir.resolve("presets");
+        java.nio.file.Files.createFile(blocker);
+        var presetFile = blocker.resolve("presets.json");
+
+        var manager = new de.zannagh.armorhider.configuration.PresetManager(presetFile);
+        manager.setActiveIndex(0);
+        var config = PlayerConfig.defaults(UUID.randomUUID(), "Editor");
+        config.helmetOpacity.setValue(0.25);
+        manager.updateActivePreset(config);
+
+        manager.flushPendingSave();
+        assertFalse(java.nio.file.Files.exists(presetFile), "precondition: the first write must have failed");
+
+        // Unblock and flush again. If the failed attempt had cleared the pending flag, this second flush
+        // would be a no-op and the user's edit would be lost with no way to recover it.
+        java.nio.file.Files.delete(blocker);
+        manager.flushPendingSave();
+
+        assertTrue(java.nio.file.Files.exists(presetFile),
+                "a failed save must remain pending so the next flush retries it");
+        assertTrue(java.nio.file.Files.readString(presetFile).contains("0.25"),
+                "the retried write must contain the edit that was pending");
+    }
+
+    @Test
     @DisplayName("A config already at the current version is still healed")
     void healRunsEvenWhenVersionIsCurrent() {
         String json = "{\"configVersion\": " + PlayerConfig.CURRENT_CONFIG_VERSION

--- a/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
+++ b/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
@@ -600,6 +600,72 @@ class PlayerConfigurationTests {
     }
 
     @Test
+    @DisplayName("Healing survives nulls inside the exclusion map instead of wiping the config")
+    void healToleratesNullExclusionEntries() {
+        // exclusionItems is a plain reflective Gson map, NOT covered by
+        // ConfigurationSourceSerializer#initializeNullConfigFields, so explicit JSON nulls reach prune()
+        // verbatim. An NPE there escapes deserialize() into PlayerConfigFileProvider's catch-all, which
+        // throws the config away and writes defaults — the exact opposite of healing it.
+        String json = """
+                {
+                  "configVersion": 12,
+                  "helmetOpacity": 0.5,
+                  "exclusionItems": {
+                    "items": {
+                      "HEAD": null,
+                      "CHEST": {"minecraft:iron_chestplate": null, "minecraft:elytra": {"displayName": "Elytra", "shouldIgnore": true}}
+                    }
+                  }
+                }
+                """;
+        var config = assertDoesNotThrow(() -> PlayerConfig.deserialize(json),
+                "healing must tolerate a corrupt exclusion map rather than throwing");
+
+        assertEquals(0.5, config.helmetOpacity.getValue(), "unrelated settings must survive the repair");
+        assertTrue(config.getExclusionItems()
+                        .getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.HEAD).isEmpty(),
+                "a null slot map must be dropped, and getItemsForSlot must never hand back null");
+        var chest = config.getExclusionItems()
+                .getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.CHEST);
+        assertFalse(chest.containsKey("minecraft:iron_chestplate"), "a null entry must be dropped");
+        assertTrue(chest.containsKey("minecraft:elytra"), "valid neighbours must be preserved");
+    }
+
+    @Test
+    @DisplayName("deepCopy tolerates a corrupt exclusion map (presets.json is never healed)")
+    void deepCopyToleratesNullExclusionEntries() {
+        var source = ExclusionItemConfiguration.deserialize(
+                "{\"items\": {\"HEAD\": null, \"CHEST\": {\"minecraft:elytra\": null}}}");
+        var copy = assertDoesNotThrow(source::deepCopy);
+        assertTrue(copy.getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.HEAD).isEmpty());
+        assertTrue(copy.getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.CHEST).isEmpty());
+    }
+
+    @Test
+    @DisplayName("updateActivePreset materialises a missing active preset instead of dropping the edit")
+    void updateActivePresetMaterialisesMissingPreset(
+            @org.junit.jupiter.api.io.TempDir java.nio.file.Path tempDir) throws Exception {
+        // activeIndex pointing at a null preset is reachable from a hand-edited or partially written file.
+        var presetFile = tempDir.resolve("presets.json");
+        java.nio.file.Files.writeString(presetFile,
+                "{\"presets\": [null, null, null, null, null], \"activeIndex\": 0}");
+
+        var manager = new de.zannagh.armorhider.configuration.PresetManager(presetFile);
+        assertNull(manager.getPreset(0), "precondition: the active slot must start empty");
+
+        var config = PlayerConfig.defaults(UUID.randomUUID(), "Editor");
+        config.helmetOpacity.setValue(0.4);
+        manager.updateActivePreset(config);
+        manager.flushPendingSave();
+
+        var preset = manager.getPreset(0);
+        assertNotNull(preset, "the edit must materialise the missing preset rather than being discarded");
+        assertEquals(0.4, preset.helmetOpacity);
+        assertTrue(java.nio.file.Files.readString(presetFile).contains("0.4"),
+                "the materialised preset must be persisted");
+    }
+
+    @Test
     @DisplayName("A failed preset save stays pending and is retried by the next flush")
     void failedPresetSaveIsRetried(@org.junit.jupiter.api.io.TempDir java.nio.file.Path tempDir)
             throws Exception {

--- a/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
+++ b/common/src/test/java/de/zannagh/armorhider/PlayerConfigurationTests.java
@@ -632,6 +632,33 @@ class PlayerConfigurationTests {
     }
 
     @Test
+    @DisplayName("Healing a self-referential global override does not throw")
+    void healToleratesSelfReferentialGlobalOverride() {
+        // Not reachable from JSON (a tree), but heal() is public API and callable on programmatically-built
+        // instances. A naive re-read of config.globalPlayerOverride after recursing would NPE here, because
+        // the recursive call nulls that very field on the shared instance when it hits the depth limit.
+        var config = PlayerConfig.defaults(UUID.randomUUID(), "SelfRef");
+        config.globalPlayerOverride = config;
+
+        var healed = assertDoesNotThrow(() -> PlayerConfig.heal(config),
+                "healing must never itself throw, even on a self-referential structure");
+        assertNull(healed.globalPlayerOverride,
+                "the self-reference exceeds the one meaningful level and must be dropped");
+    }
+
+    @Test
+    @DisplayName("An items:null exclusion map is repaired AND marked for persistence")
+    void healPersistsNullItemsMapRepair() {
+        // prune() must report the null-map materialisation as a repair (> 0), otherwise heal() never flags the
+        // config dirty and the "items": null corruption is re-read and re-repaired on every launch, forever.
+        var exclusions = ExclusionItemConfiguration.deserialize("{\"items\": null}");
+        assertTrue(exclusions.prune() > 0, "materialising a null backing map must count as a repair");
+        // Idempotent: a second pass over the now-healthy map reports nothing to do.
+        assertEquals(0, exclusions.prune(), "a healthy map needs no further repair");
+        assertTrue(exclusions.getItemsForSlot(net.minecraft.world.entity.EquipmentSlot.HEAD).isEmpty());
+    }
+
+    @Test
     @DisplayName("deepCopy tolerates a corrupt exclusion map (presets.json is never healed)")
     void deepCopyToleratesNullExclusionEntries() {
         var source = ExclusionItemConfiguration.deserialize(


### PR DESCRIPTION
This PR addresses a few potential (and probably already ocurring issues):
* with an active preset, immediate saves to the preset configs could interfere with client UI ticks
* payloads sent to the server are now pruned to prevent huge payload sizes
* inability to close armor hider's config screen when there's another issue than a file save problem
* simultaneously closing the settings screen while holding the hotkey to open it could cause the client to freeze 