### PR TITLE
fix: 26.2 water translucency

### DIFF
--- a/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
@@ -255,8 +255,19 @@ if (branch == "fabric") {
     // FCGT (fabric-client-gametest-api-v1) entrypoint registered only on Fabric variants
     // that pin `fabricapi.semver` (currently fabric-26.2). Other variants emit "[]" so the
     // JSON stays valid and fabric-loader simply ignores it.
+    val fcgtTests = buildList {
+        add("de.zannagh.armorhider.smoke.EntityRenderSmokeTest")
+        add("de.zannagh.armorhider.smoke.IndividualConfigSmokeTest")
+        add("de.zannagh.armorhider.smoke.KeybindSmokeTest")
+        // WaterTransparencySmokeTest drives the after-terrain feature phase (the fix), which only
+        // exists >= 26.2-1.pre — its class is stonecutter-gated to the same floor, so only register
+        // the entrypoint there or fabric-loader would fail to find the commented-out class.
+        if (sc.current.parsed >= "26.2-1.pre") {
+            add("de.zannagh.armorhider.smoke.WaterTransparencySmokeTest")
+        }
+    }
     val fcgtEntries = if (hasProperty("fabricapi.semver"))
-        "[\"de.zannagh.armorhider.smoke.EntityRenderSmokeTest\", \"de.zannagh.armorhider.smoke.IndividualConfigSmokeTest\", \"de.zannagh.armorhider.smoke.KeybindSmokeTest\"]"
+        fcgtTests.joinToString(", ", "[", "]") { "\"$it\"" }
     else
         "[]"
 

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/hand/SubmitNodeCollectorMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/hand/SubmitNodeCollectorMixin.java
@@ -5,6 +5,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import de.zannagh.armorhider.client.api.AhRenderManagementApi;
 import de.zannagh.armorhider.client.common.RenderScope;
+import de.zannagh.armorhider.client.render.rendertype.ArmorHiderRenderTypes;
 import net.minecraft.client.renderer.SubmitNodeCollection;
 //? if < 26.2-1.pre
 //import net.minecraft.client.renderer.SubmitNodeStorage;
@@ -35,6 +36,31 @@ import org.spongepowered.asm.mixin.Shadow;
 @SuppressWarnings({"unused", "UnusedMixin"})
 @Mixin(SubmitNodeCollection.class)
 public class SubmitNodeCollectorMixin {
+
+    //? if >= 26.2-1.pre {
+    // Our translucent (depth-write-disabled) armor/entity render types must be drawn AFTER the
+    // translucent terrain layer (water, ice, stained glass), not in the pre-terrain
+    // translucentModels phase. Otherwise terrain drawn afterwards overdraws the parts of a piece
+    // that aren't backed by an opaque body pixel — e.g. a chestplate's shoulder pads silhouetted
+    // against a body of water vanish, while the same pads render fine against a solid block.
+    // afterTerrain is the vanilla feature phase executed right after translucentTerrain (see
+    // LevelRenderer#addMainPass → FeatureRenderDispatcher.PreparedFrame#executeTranslucentAfterTerrain).
+    @Shadow @Final public SimpleFeatureRenderPhase afterTerrain;
+
+    // Route a model submit into the after-terrain phase when it carries one of our deferred
+    // translucent types; return true when it was handled here (caller must not submit it again).
+    @Unique
+    private boolean armorHider$deferAfterTerrain(SubmitNode submit) {
+        if (ArmorHiderRenderTypes.isDeferralEnabled()
+                && submit instanceof ModelFeatureRenderer.Submit<?> modelSubmit
+                && ArmorHiderRenderTypes.isDeferredType(modelSubmit.renderType())) {
+            this.afterTerrain.submit(submit);
+            ArmorHiderRenderTypes.recordDeferredSubmit();
+            return true;
+        }
+        return false;
+    }
+    //?}
 
     //? if <= 26.1.2 {
     /*@WrapOperation(
@@ -173,7 +199,11 @@ public class SubmitNodeCollectorMixin {
         // OFFHAND only — see comment on forceTranslucentRoute.
         var activeCtx = AhRenderManagementApi.getActiveScope(RenderScope.OFFHAND);
         if (activeCtx.isEmpty() || !armorHider$isFading(activeCtx.modification().transparency())) {
-            original.call(phase, submit);
+            // Armor/elytra submits arrive here (no OFFHAND scope) already carrying our translucent
+            // type — defer them past the terrain instead of drawing them into translucentModels.
+            if (!armorHider$deferAfterTerrain(submit)) {
+                original.call(phase, submit);
+            }
             return;
         }
         var modApi = activeCtx.renderModificationApi();
@@ -192,7 +222,10 @@ public class SubmitNodeCollectorMixin {
                 modelSubmit.uvMapping(), modelSubmit.sheetedDecalPose()
         );
 
-        original.call(phase, (SubmitNode) modified);
+        // The rebuilt offhand item now carries our translucent type too — defer it past the terrain.
+        if (!armorHider$deferAfterTerrain((SubmitNode) modified)) {
+            original.call(phase, (SubmitNode) modified);
+        }
     }
     *///?} else {
     @WrapOperation(
@@ -211,7 +244,11 @@ public class SubmitNodeCollectorMixin {
         // OFFHAND only — see comment on forceTranslucentRoute.
         var activeCtx = AhRenderManagementApi.getActiveScope(RenderScope.OFFHAND);
         if (activeCtx.isEmpty() || !armorHider$isFading(activeCtx.modification().transparency())) {
-            original.call(phase, submit);
+            // Armor/elytra submits arrive here (no OFFHAND scope) already carrying our translucent
+            // type — defer them past the terrain instead of drawing them into translucentModels.
+            if (!armorHider$deferAfterTerrain(submit)) {
+                original.call(phase, submit);
+            }
             return;
         }
         var modApi = activeCtx.renderModificationApi();
@@ -229,7 +266,10 @@ public class SubmitNodeCollectorMixin {
                 modelSubmit.sprite(), modelSubmit.sheetedDecalPose()
         );
 
-        original.call(phase, (TranslucentSubmit) modified);
+        // The rebuilt offhand item now carries our translucent type too — defer it past the terrain.
+        if (!armorHider$deferAfterTerrain((SubmitNode) modified)) {
+            original.call(phase, (TranslucentSubmit) modified);
+        }
     }
     //?}
 

--- a/common/src/client/java/de/zannagh/armorhider/client/render/rendertype/ArmorHiderRenderTypes.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/render/rendertype/ArmorHiderRenderTypes.java
@@ -1,5 +1,7 @@
 package de.zannagh.armorhider.client.render.rendertype;
 import net.minecraft.client.renderer.Sheets;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 //?if >= 1.21.11 {
@@ -54,6 +56,57 @@ public final class ArmorHiderRenderTypes {
     private static <T, R> Function<T, R> memoize(Function<T, R> fn) {
         var cache = new ConcurrentHashMap<T, R>();
         return t -> cache.computeIfAbsent(t, fn);
+    }
+
+    // Set of every translucent-no-depth-write render type this class hands out. These are the types
+    // whose armor/entity draws must be deferred to the after-translucent-terrain render phase
+    // (>= 26.2-1.pre) so translucent terrain (water, ice, stained glass) drawn afterwards cannot
+    // overdraw the parts of a piece that aren't backed by an opaque body pixel — e.g. chestplate
+    // shoulder pads silhouetted against a body of water. We store the exact memoized instances we
+    // produce (and each carries a unique "armor_hider_*" name), so a plain contains-check is a
+    // reliable membership test and the set stays tiny (one entry per texture actually used).
+    private static final Set<Object> DEFERRED_TYPES = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    /**
+     * Whether the given render type is one of this mod's translucent-no-depth-write types that must
+     * be routed into the after-terrain phase. Cross-version safe: takes {@code Object} so the
+     * feature-dispatcher mixin can call it without importing the version-specific {@code RenderType}.
+     *
+     * @param renderType the render type a model submit is about to be enqueued with.
+     * @return {@code true} when the draw should be deferred until after translucent terrain.
+     */
+    public static boolean isDeferredType(Object renderType) {
+        return renderType != null && DEFERRED_TYPES.contains(renderType);
+    }
+
+    // Diagnostic counter of how many model submits have been deferred into the after-terrain phase.
+    // The after-terrain redirect fails *silently* if the mixin target drifts between versions (the
+    // piece just reverts to the old overdraw-by-water behaviour), so — matching this repo's
+    // smoke-test convention of asserting a mixin actually fired rather than only "didn't crash" —
+    // the water-scene game test asserts this climbs above zero.
+    private static final java.util.concurrent.atomic.AtomicLong DEFERRED_SUBMIT_COUNT =
+            new java.util.concurrent.atomic.AtomicLong();
+
+    public static void recordDeferredSubmit() {
+        DEFERRED_SUBMIT_COUNT.incrementAndGet();
+    }
+
+    public static long deferredSubmitCount() {
+        return DEFERRED_SUBMIT_COUNT.get();
+    }
+
+    // Test-only diagnostic switch. When flipped off, the after-terrain redirect is bypassed and the
+    // translucent armor falls back to the pre-terrain phase — i.e. the pre-fix behaviour where water
+    // overdraws the pads. The water-scene game test toggles this to capture a before/after and to
+    // assert the redirect both fires when on and stays quiet when off. Always true in normal play.
+    private static volatile boolean deferralEnabled = true;
+
+    public static void setDeferralEnabled(boolean enabled) {
+        deferralEnabled = enabled;
+    }
+
+    public static boolean isDeferralEnabled() {
+        return deferralEnabled;
     }
 
     // --- Pipelines (>= 1.21.5) ---
@@ -363,11 +416,15 @@ public final class ArmorHiderRenderTypes {
     // --- Public API ---
 
     public static RenderType translucentArmor(Identifier texture) {
-        return TRANSLUCENT_ARMOR.apply(texture);
+        RenderType renderType = TRANSLUCENT_ARMOR.apply(texture);
+        DEFERRED_TYPES.add(renderType);
+        return renderType;
     }
 
     public static RenderType translucentEntity(Identifier texture) {
-        return TRANSLUCENT_ENTITY.apply(texture);
+        RenderType renderType = TRANSLUCENT_ENTITY.apply(texture);
+        DEFERRED_TYPES.add(renderType);
+        return renderType;
     }
 
     public static RenderType translucentArmorTrim() {

--- a/common/src/client/java/de/zannagh/armorhider/smoke/WaterTransparencySmokeTest.java
+++ b/common/src/client/java/de/zannagh/armorhider/smoke/WaterTransparencySmokeTest.java
@@ -1,0 +1,208 @@
+// Drives the after-terrain feature phase, which only exists >= 26.2-1.pre; older fcgt variants
+// (1.21.x, 26.1.x, 26.2 snapshots) use a different render architecture and also predate the FCGT
+// API this test compiles against, so gate the whole class to where both line up.
+//? if fcgt && >= 26.2-1.pre {
+package de.zannagh.armorhider.smoke;
+
+import de.zannagh.armorhider.ArmorHider;
+import de.zannagh.armorhider.client.ArmorHiderClient;
+import de.zannagh.armorhider.client.render.rendertype.ArmorHiderRenderTypes;
+import net.fabricmc.fabric.api.client.gametest.v1.FabricClientGameTest;
+import net.fabricmc.fabric.api.client.gametest.v1.context.ClientGameTestContext;
+import net.fabricmc.fabric.api.client.gametest.v1.context.TestSingleplayerContext;
+import net.minecraft.client.CameraType;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.worldselection.WorldCreationUiState;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.nio.file.Path;
+
+/**
+ * Phase 3 water-transparency render smoke (fabric-client-gametest-api-v1).
+ * <p>
+ * Reproduces the reported artifact: a semi-transparent chestplate's shoulder pads (pauldrons)
+ * vanish when silhouetted against a body of water, because the translucent-no-depth-write armor
+ * was drawn in the pre-terrain {@code translucentModels} phase and the translucent water terrain,
+ * drawn afterwards, overdrew the pad pixels not backed by an opaque body pixel. The fix routes our
+ * translucent armor into the vanilla {@code afterTerrain} feature phase (drawn after the
+ * translucent terrain layer) so the pads blend over the already-present water instead.
+ * <p>
+ * The scene is built entirely with {@link ServerLevel#setBlock} (no {@code /fill} commands, so no
+ * command feedback clutters the chat overlay): a tall, wide backdrop wall a few blocks in front of
+ * a hovering player, from a near-horizontal third-person-back camera — so the pauldrons that
+ * protrude past the body silhouette are seen against the wall with no opaque body pixel behind them.
+ * The wall is placed with {@code UPDATE_CLIENTS} (no neighbour updates), which keeps the water as
+ * non-flowing source blocks — a stable vertical water backdrop vanilla fluid physics would drain.
+ * <p>
+ * Three shots are captured from an identical, snapped pose for eyeballing (FCGT does no pixel diffing
+ * here): the redirect toggled off (pre-fix — water overdraws the pads), toggled on (fixed), and a
+ * stone-backdrop control. The machine-checked assertions are that the deferral stays quiet while the
+ * redirect is off ({@link ArmorHiderRenderTypes#deferredSubmitCount()} flat) and fires while it is on
+ * — guarding, per this repo's smoke-test convention, against the mixin silently missing its target on
+ * a version bump, which would revert the piece to the old overdraw behaviour with no crash to notice.
+ * <p>
+ * Gated to the {@code fcgt} constant and, via the render architecture it drives, effectively to
+ * {@code >= 26.2-1.pre} where the feature-phase {@code afterTerrain} model phase exists. Currently
+ * wired for fabric-26.2.
+ */
+public final class WaterTransparencySmokeTest implements FabricClientGameTest {
+
+    // Near-horizontal back view (matches the reported third-person scenario): the pauldrons that
+    // protrude sideways past the body silhouette are seen against the water backdrop behind the
+    // player, with no opaque body pixel behind them — exactly the pixels the bug drops.
+    private static final float CAMERA_PITCH = 8.0F;
+
+    @Override
+    public void runTest(ClientGameTestContext context) {
+        ArmorHider.LOGGER.info("[smoke/fcgt] Water transparency smoke starting");
+        context.waitForScreen(TitleScreen.class);
+
+        try (TestSingleplayerContext singleplayer = context.worldBuilder()
+                .setUseConsistentSettings(true)
+                .adjustSettings(state -> {
+                    state.setGameMode(WorldCreationUiState.SelectedGameMode.CREATIVE);
+                    state.setGenerateStructures(false);
+                })
+                .create()) {
+            ArmorHider.LOGGER.info("[smoke/fcgt] World created, building water pool arena");
+
+            var server = singleplayer.getServer();
+            server.runOnServer(mcServer -> {
+                buildArena(mcServer.overworld(), Blocks.WATER.defaultBlockState());
+                var sp = mcServer.getPlayerList().getPlayers().get(0);
+                // Hover the player (creative flight, no gravity) so nothing opaque sits behind the
+                // sideways pauldrons — only the water wall does. Facing +Z (yaw 0) toward the wall.
+                var abilities = sp.getAbilities();
+                abilities.mayfly = true;
+                abilities.flying = true;
+                sp.onUpdateAbilities();
+                sp.setNoGravity(true);
+                sp.connection.teleport(0.5, 96.0, 0.5, 0.0F, CAMERA_PITCH);
+            });
+
+            context.runOnClient(client -> {
+                var player = client.player;
+                if (player == null) {
+                    throw new IllegalStateException("[smoke/fcgt] Client player did not spawn");
+                }
+                player.setItemSlot(EquipmentSlot.CHEST, new ItemStack(Items.DIAMOND_CHESTPLATE));
+                // Reassert rotation + flight client-side so the framing is deterministic.
+                player.setYRot(0.0F);
+                player.setXRot(CAMERA_PITCH);
+                player.setYHeadRot(0.0F);
+                player.getAbilities().flying = true;
+                player.setNoGravity(true);
+                client.options.setCameraType(CameraType.THIRD_PERSON_BACK);
+
+                // A prior smoke test (keybind) flips the session disable override on and clears it again;
+                // clear it defensively so the chest actually fades here regardless of test ordering.
+                ArmorHiderClient.CLIENT_CONFIG_MANAGER.clearSessionDisableOverride();
+                var config = ArmorHiderClient.CLIENT_CONFIG_MANAGER
+                        .resolveConfig(ArmorHiderClient.getCurrentPlayerName());
+                // 80% chest opacity → the reported case: mostly-opaque pads that must survive over water.
+                config.chestOpacity.setValue(0.8);
+
+                // Start with the redirect OFF to capture the pre-fix "before": pads overdrawn by water.
+                ArmorHiderRenderTypes.setDeferralEnabled(false);
+            });
+
+            singleplayer.getClientLevel().waitForChunksRender();
+            singleplayer.getClientLevel().waitForChunksRender();
+            context.waitTicks(40);
+
+            // BEFORE — redirect off: the faded armor is drawn in the pre-terrain phase, so the water
+            // overdraws the pads that aren't backed by an opaque body pixel (the reported bug).
+            context.runOnClient(WaterTransparencySmokeTest::snapPose);
+            context.waitTicks(3);
+            long brokenStart = context.computeOnClient(client -> ArmorHiderRenderTypes.deferredSubmitCount());
+            Path brokenShot = context.takeScreenshot("armorhider_1_water_redirect_off");
+            long brokenEnd = context.computeOnClient(client -> ArmorHiderRenderTypes.deferredSubmitCount());
+            ArmorHider.LOGGER.info("[smoke/fcgt] BEFORE (redirect off) screenshot: {}", brokenShot);
+
+            // AFTER — redirect on: the faded armor draws in the after-terrain phase, over the water.
+            // Same pose (snapped again) so the before/after is a clean pixel-comparable pair.
+            context.runOnClient(client -> {
+                ArmorHiderRenderTypes.setDeferralEnabled(true);
+                snapPose(client);
+            });
+            context.waitTicks(6);
+            long fixedStart = context.computeOnClient(client -> ArmorHiderRenderTypes.deferredSubmitCount());
+            Path fixedShot = context.takeScreenshot("armorhider_2_water_redirect_on");
+            long fixedEnd = context.computeOnClient(client -> ArmorHiderRenderTypes.deferredSubmitCount());
+            ArmorHider.LOGGER.info("[smoke/fcgt] AFTER (redirect on) screenshot: {}", fixedShot);
+
+            // Control — same pose, redirect on, but background swapped to solid stone. Pre-fix this
+            // rendered the pads fine; it should look the same as the water AFTER shot.
+            server.runOnServer(mcServer -> buildArena(mcServer.overworld(), Blocks.STONE.defaultBlockState()));
+            singleplayer.getClientLevel().waitForChunksRender();
+            context.runOnClient(WaterTransparencySmokeTest::snapPose);
+            context.waitTicks(6);
+            Path stoneShot = context.takeScreenshot("armorhider_3_solid_redirect_on");
+            ArmorHider.LOGGER.info("[smoke/fcgt] CONTROL (solid background) screenshot: {}", stoneShot);
+
+            long deltaBroken = brokenEnd - brokenStart;
+            long deltaFixed = fixedEnd - fixedStart;
+            if (deltaBroken != 0) {
+                throw new IllegalStateException("[smoke/fcgt] redirect fired while disabled (delta "
+                        + deltaBroken + ") — the deferral toggle is not honoured");
+            }
+            if (deltaFixed <= 0) {
+                throw new IllegalStateException(
+                        "[smoke/fcgt] after-terrain deferral never fired while enabled (delta " + deltaFixed
+                                + ") — the translucent armor is still drawn before the water terrain;"
+                                + " the redirect mixin missed its target");
+            }
+            ArmorHider.LOGGER.info("[smoke/fcgt] deferrals: off-window={}, on-window={}", deltaBroken, deltaFixed);
+
+            ArmorHider.LOGGER.info("[smoke/fcgt] Water transparency smoke complete");
+        }
+    }
+
+    // Builds a tall, wide backdrop wall a few blocks in front of the hovering player (at +Z, the
+    // side the third-person-back camera looks toward). {@code wall} is water for the reproduction,
+    // stone for the comparison shot. UPDATE_CLIENTS syncs to the client without neighbour updates,
+    // so the water is placed as non-flowing source blocks — a stable vertical water backdrop that
+    // vanilla fluid physics would otherwise drain in a second.
+    private static void buildArena(ServerLevel level, BlockState wall) {
+        BlockState air = Blocks.AIR.defaultBlockState();
+        fill(level, -20, 66, -6, 20, 128, 22, air);   // clear the arena around player + wall
+        fill(level, -18, 70, 8, 18, 116, 9, wall);     // tall, wide backdrop wall at z=8..9
+    }
+
+    // Re-pin the player to an exact, motionless pose so every screenshot is framed identically
+    // (the before/after pair must be pixel-comparable) and flight/no-gravity can't lapse mid-run.
+    private static void snapPose(Minecraft client) {
+        var player = client.player;
+        if (player == null) {
+            return;
+        }
+        player.setPos(0.5, 96.0, 0.5);
+        player.setDeltaMovement(0.0, 0.0, 0.0);
+        player.setYRot(0.0F);
+        player.setXRot(CAMERA_PITCH);
+        player.setYHeadRot(0.0F);
+        player.setYBodyRot(0.0F);
+        player.getAbilities().flying = true;
+        player.setNoGravity(true);
+    }
+
+    private static void fill(ServerLevel level, int x0, int y0, int z0, int x1, int y1, int z1, BlockState state) {
+        BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos();
+        for (int x = x0; x <= x1; x++) {
+            for (int y = y0; y <= y1; y++) {
+                for (int z = z0; z <= z1; z++) {
+                    level.setBlock(pos.set(x, y, z), state, Block.UPDATE_CLIENTS);
+                }
+            }
+        }
+    }
+}
+//?}


### PR DESCRIPTION
This PR adds that the rendering makes use of the afterTerrain render pass to properly have semi-transparent armor drawn infront of water bodies.