### PR TITLE
feat: add compat to immersive armors

### DIFF
--- a/buildSrc/src/main/kotlin/multiloader-loader.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-loader.gradle.kts
@@ -11,7 +11,8 @@ sc.constants["neoforge"] = sc.current.project.contains("neoforge")
 val compatKeys = listOf(
     "fabricapi",
     "gender", "geckolib", "waveycapes", "mekanism", "figura",
-    "elytratrims", "iris", "emf", "etf", "modmenu", "deeperdarker", "uranus", "firstperson"
+    "elytratrims", "iris", "emf", "etf", "modmenu", "deeperdarker", "uranus", "firstperson",
+    "immersivearmors"
 )
 val availableHashes = compatKeys.mapNotNull { key ->
     findProperty("$key.version")?.toString()?.let { hash -> key to hash }

--- a/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-loom.gradle.kts
@@ -49,6 +49,11 @@ with(sc) {
     constants["deeperdarker_horn"] = hasProperty("deeperdarker.version") && findProperty("deeperdarker.warden_class") != "true"
     // Uranus lib (iafenvoy, e.g. Ice and Fire: CE) — custom armor rendering via IArmorRendererBase.
     constants["uranus"] = hasProperty("uranus.version")
+    // Immersive Armors (Conczin) cancels the vanilla equipment layer and draws its armor as its own
+    // `Piece` list. It only ships for 1.20.1, 1.21.1, 26.1.2 and 26.2, and its render path changed
+    // shape twice across those (float rgb → packed argb → SubmitNodeCollector), so the compat mixins
+    // only compile on the variants where the two mods actually overlap.
+    constants["immersivearmors"] = hasProperty("immersivearmors.version")
     // `gender` activates the modern GenderArmorLayer-based mixin.
     // `gender_legacy` activates the GenderLayer.render() coarse mixin for older
     // mod builds (e.g. female-gender NeoForge 1.21/1.21.1, hash kKffHCGl) whose

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/immersivearmors/ImmersiveArmorsPieceGeometryMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/immersivearmors/ImmersiveArmorsPieceGeometryMixin.java
@@ -1,0 +1,203 @@
+//? if immersivearmors {
+package de.zannagh.armorhider.client.mixin.compat.immersivearmors;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import de.zannagh.armorhider.client.api.AhRenderManagementApi;
+import de.zannagh.armorhider.client.common.RenderScope;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.resources.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+//? if >= 26.1-0.snapshot {
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+//?}
+
+//? if >= 1.21 && < 26.1-0.snapshot {
+/*import org.spongepowered.asm.mixin.injection.ModifyVariable;
+*///?}
+
+//? if < 1.21 {
+/*import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.model.EntityModel;
+*///?}
+
+/**
+ * Compatibility mixin for Immersive Armors' {@code Piece} base class.
+ *
+ * <p>Immersive Armors replaces vanilla armor rendering wholesale: its own
+ * {@code MixinHumanoidArmorLayer} cancels {@code HumanoidArmorLayer.renderArmorPiece} at HEAD for
+ * every {@code ExtendedArmorItem} and draws a list of {@code Piece}s instead. That means none of
+ * Armor Hider's vanilla equipment-layer hooks ever see these items — the piece geometry has to be
+ * faded where Immersive Armors actually emits it.
+ *
+ * <p>This mixin owns the two levers that live on the shared base class:
+ * <ul>
+ *   <li>the packed ARGB colour handed to the geometry, and</li>
+ *   <li>the {@code armorCutoutNoCull} render type, which discards partial alpha and therefore has
+ *       to be swapped for a translucent one before a fade is visible at all.</li>
+ * </ul>
+ *
+ * <p>Scope setup/teardown and the piece types that bypass the base class live in
+ * {@link ImmersiveArmorsPieceMixin}.
+ */
+@SuppressWarnings("UnresolvedMixinReference")
+@Pseudo
+@Mixin(targets = "immersive_armors.client.render.entity.piece.Piece", remap = false)
+public class ImmersiveArmorsPieceGeometryMixin {
+
+    // ========================
+    // Colour / alpha
+    // ========================
+
+    //? if >= 26.1-0.snapshot {
+    /**
+     * On 26.1+ every non-item piece funnels through {@code Piece#renderGeometry} — layer pieces,
+     * deco models, gears, capes, armor trims and the glint pass all end up here. Fading the colour
+     * argument at this single choke point covers the lot.
+     *
+     * <p>{@code renderGeometry} is overloaded (the 8-arg form delegates to the 9-arg form), so this
+     * runs twice for the delegating path. That is harmless: {@code applyArmorTransparency} sets an
+     * absolute alpha via {@code ColorMath.withAlpha} rather than scaling it, so it is idempotent.
+     */
+    @ModifyVariable(method = "renderGeometry", at = @At("HEAD"), argsOnly = true, ordinal = 2, require = 0)
+    private int armorHider$fadePieceColor(int color) {
+        return AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE)
+                .renderModificationApi().applyArmorTransparency(color);
+    }
+    //?}
+
+    //? if >= 1.21 && < 26.1-0.snapshot {
+    /*/^*
+     * Pre-26.1 there is no {@code renderGeometry} funnel: {@code renderParts} draws layer and deco
+     * pieces directly. Gear, cape and trim geometry is emitted by the subclasses and is handled in
+     * {@link ImmersiveArmorsPieceMixin}.
+     ^/
+    @ModifyVariable(method = "renderParts", at = @At("HEAD"), argsOnly = true, ordinal = 1, require = 0)
+    private int armorHider$fadePieceColor(int color) {
+        return AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE)
+                .renderModificationApi().applyArmorTransparency(color);
+    }
+    *///?}
+
+    //? if < 1.21 {
+    /*/^*
+     * On 1.20.1 {@code renderParts} carries loose red/green/blue floats and hardcodes alpha to 1.0,
+     * so there is no colour argument to fade — the alpha has to be substituted at the draw call.
+     ^/
+    @WrapOperation(
+            method = "renderParts",
+            require = 0,
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/client/model/EntityModel;renderToBuffer(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;IIFFFF)V",
+                    remap = true)
+    )
+    private void armorHider$fadePieceAlpha(EntityModel<?> model, PoseStack poseStack, VertexConsumer vertexConsumer,
+            int packedLight, int packedOverlay, float red, float green, float blue, float alpha,
+            Operation<Void> original) {
+        var ctx = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE);
+        if (ctx.isEmpty()) {
+            original.call(model, poseStack, vertexConsumer, packedLight, packedOverlay, red, green, blue, alpha);
+            return;
+        }
+        original.call(model, poseStack, vertexConsumer, packedLight, packedOverlay, red, green, blue,
+                ctx.renderModificationApi().getTransparencyAlpha());
+    }
+    *///?}
+
+    // ========================
+    // Render type
+    // ========================
+    //
+    // armorCutoutNoCull discards partial alpha, so the colour fade above is invisible until the
+    // render type is swapped for a translucent one. The entityTranslucent and beaconBeam branches
+    // Immersive Armors picks for its `translucent()`/`glowing()` pieces already blend, so only the
+    // cutout default needs intercepting.
+
+    //? if >= 26.1-0.snapshot {
+    @WrapOperation(
+            method = "renderParts",
+            require = 0,
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/rendertype/RenderTypes;armorCutoutNoCull(Lnet/minecraft/resources/Identifier;)Lnet/minecraft/client/renderer/rendertype/RenderType;",
+                    remap = true)
+    )
+    private RenderType armorHider$translucentPieceRenderType(Identifier texture, Operation<RenderType> original) {
+        var modApi = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE).renderModificationApi();
+        var originalType = original.call(texture);
+        if (modApi.getTranslucentArmorRenderType(texture, originalType) instanceof RenderType rt) {
+            return rt;
+        }
+        return originalType;
+    }
+    //?}
+
+    //? if < 26.1-0.snapshot {
+    /*@WrapOperation(
+            method = "renderParts",
+            require = 0,
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/rendertype/RenderType;armorCutoutNoCull(Lnet/minecraft/resources/Identifier;)Lnet/minecraft/client/renderer/rendertype/RenderType;",
+                    remap = true)
+    )
+    private RenderType armorHider$translucentPieceRenderType(Identifier texture, Operation<RenderType> original) {
+        var modApi = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE).renderModificationApi();
+        var originalType = original.call(texture);
+        if (modApi.getTranslucentArmorRenderType(texture, originalType) instanceof RenderType rt) {
+            return rt;
+        }
+        return originalType;
+    }
+    *///?}
+
+    // ========================
+    // Glint
+    // ========================
+    //
+    // The glint predicate is `hasGlint() || itemStack.hasFoil() && <config>`, i.e. a piece can be
+    // permanently glinting regardless of enchantments. Both halves are suppressed so a hidden or
+    // faded piece does not keep a fully opaque foil overlay.
+
+    @ModifyExpressionValue(
+            method = "renderParts",
+            require = 0,
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/world/item/ItemStack;hasFoil()Z",
+                    remap = true)
+    )
+    private boolean armorHider$suppressPieceItemGlint(boolean original) {
+        return armorHider$glint(original);
+    }
+
+    @ModifyExpressionValue(
+            method = "renderParts",
+            require = 0,
+            at = @At(value = "INVOKE",
+                    target = "Limmersive_armors/client/render/entity/piece/Piece;hasGlint()Z",
+                    remap = false)
+    )
+    private boolean armorHider$suppressPieceIntrinsicGlint(boolean original) {
+        return armorHider$glint(original);
+    }
+
+    @Unique
+    private boolean armorHider$glint(boolean original) {
+        if (!original) {
+            return false;
+        }
+        var ctx = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE);
+        if (ctx.isEmpty()) {
+            return true;
+        }
+        if (ctx.modification().shouldHide()) {
+            return false;
+        }
+        return ctx.renderModificationApi().getHasFoil(true);
+    }
+}
+//?}

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/immersivearmors/ImmersiveArmorsPieceMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/immersivearmors/ImmersiveArmorsPieceMixin.java
@@ -1,0 +1,198 @@
+//? if immersivearmors {
+package de.zannagh.armorhider.client.mixin.compat.immersivearmors;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.vertex.PoseStack;
+import de.zannagh.armorhider.client.api.AhRenderManagementApi;
+import de.zannagh.armorhider.client.common.IdentityCarrier;
+import de.zannagh.armorhider.client.common.RenderScope;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+
+//? if >= 26.1-0.snapshot {
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+//?}
+
+//? if < 26.1-0.snapshot {
+/*import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+*///?}
+
+/**
+ * Compatibility mixin for the concrete Immersive Armors piece types.
+ *
+ * <p>Immersive Armors draws an armor item as a list of {@code Piece}s, each of which implements
+ * {@code render}. This mixin is applied to every concrete implementation so that a render scope is
+ * opened around each piece, carrying the slot, item and player identity that Armor Hider needs to
+ * resolve opacity, item exclusions and combat fading.
+ *
+ * <p>The scope is deliberately self-contained rather than inherited from Armor Hider's own
+ * {@code HumanoidArmorLayerMixin}. Immersive Armors cancels the vanilla equipment layer at HEAD, and
+ * the relative order of two HEAD injections from different mods is not guaranteed: if Armor Hider's
+ * hook wins the race it opens a scope whose RETURN teardown is then skipped by the cancel. Opening
+ * and closing the scope here makes the outcome identical either way and re-closes a scope leaked by
+ * that race.
+ *
+ * <p>Base-class geometry (colour, render type, glint) is handled in
+ * {@link ImmersiveArmorsPieceGeometryMixin}.
+ */
+@SuppressWarnings("UnresolvedMixinReference")
+@Pseudo
+@Mixin(targets = {
+        "immersive_armors.client.render.entity.piece.LayerPiece",
+        "immersive_armors.client.render.entity.piece.ModelPiece",
+        "immersive_armors.client.render.entity.piece.GearPiece",
+        "immersive_armors.client.render.entity.piece.CapePiece",
+        "immersive_armors.client.render.entity.piece.ItemPiece"
+}, remap = false)
+public class ImmersiveArmorsPieceMixin {
+
+    // ========================
+    // Scope lifecycle
+    // ========================
+
+    @Inject(method = "render", at = @At("HEAD"), cancellable = true, require = 0)
+    //? if >= 26.1-0.snapshot
+    private void armorHider$enterPiece(PoseStack poseStack, SubmitNodeCollector collector, int light, HumanoidRenderState renderState, ItemStack itemStack, float tickDelta, EquipmentSlot armorSlot, HumanoidModel<?> armorModel, int order, CallbackInfoReturnable<Integer> cir) {
+    //? if < 26.1-0.snapshot
+    //private void armorHider$enterPiece(PoseStack poseStack, MultiBufferSource bufferSource, int light, LivingEntity entity, ItemStack itemStack, float tickDelta, EquipmentSlot armorSlot, HumanoidModel<?> armorModel, CallbackInfo ci) {
+
+        //? if >= 26.1-0.snapshot
+        Object identitySource = renderState;
+        //? if < 26.1-0.snapshot
+        //Object identitySource = entity;
+
+        if (!(identitySource instanceof IdentityCarrier carrier)) {
+            return;
+        }
+        var ctx = AhRenderManagementApi.enterScope(RenderScope.ARMOR_PIECE, carrier, armorSlot, itemStack);
+        if (ctx.shouldCancel()) {
+            AhRenderManagementApi.exitScope(RenderScope.ARMOR_PIECE);
+            //? if >= 26.1-0.snapshot
+            cir.setReturnValue(order);
+            //? if < 26.1-0.snapshot
+            //ci.cancel();
+        }
+    }
+
+    @Inject(method = "render", at = @At("RETURN"), require = 0)
+    //? if >= 26.1-0.snapshot
+    private void armorHider$exitPiece(CallbackInfoReturnable<Integer> cir) {
+    //? if < 26.1-0.snapshot
+    //private void armorHider$exitPiece(CallbackInfo ci) {
+        AhRenderManagementApi.exitScope(RenderScope.ARMOR_PIECE);
+    }
+
+    // ========================
+    // Render types owned by the subclasses
+    // ========================
+    //
+    // Gear and cape geometry never reaches Piece#renderParts — both hardcode armorCutoutNoCull in
+    // their own class — so the translucent swap has to be repeated here. `require = 0` keeps this
+    // inert on the piece types that carry no such call, and across the Immersive Armors versions
+    // that emit the cape from `render` rather than a separate `renderCape`.
+
+    //? if >= 26.1-0.snapshot {
+    @WrapOperation(
+            method = {"render", "renderCape"},
+            require = 0,
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/rendertype/RenderTypes;armorCutoutNoCull(Lnet/minecraft/resources/Identifier;)Lnet/minecraft/client/renderer/rendertype/RenderType;",
+                    remap = true)
+    )
+    private RenderType armorHider$translucentSubPieceRenderType(Identifier texture, Operation<RenderType> original) {
+        var modApi = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE).renderModificationApi();
+        var originalType = original.call(texture);
+        if (modApi.getTranslucentArmorRenderType(texture, originalType) instanceof RenderType rt) {
+            return rt;
+        }
+        return originalType;
+    }
+    //?}
+
+    //? if < 26.1-0.snapshot {
+    /*@WrapOperation(
+            method = {"render", "renderCape"},
+            require = 0,
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/rendertype/RenderType;armorCutoutNoCull(Lnet/minecraft/resources/Identifier;)Lnet/minecraft/client/renderer/rendertype/RenderType;",
+                    remap = true)
+    )
+    private RenderType armorHider$translucentSubPieceRenderType(Identifier texture, Operation<RenderType> original) {
+        var modApi = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE).renderModificationApi();
+        var originalType = original.call(texture);
+        if (modApi.getTranslucentArmorRenderType(texture, originalType) instanceof RenderType rt) {
+            return rt;
+        }
+        return originalType;
+    }
+    *///?}
+
+    // ========================
+    // Colour owned by the subclasses (pre-26.1 only)
+    // ========================
+    //
+    // From 26.1 gear/cape geometry goes through Piece#renderGeometry and is faded there. Before
+    // that, both draw straight from their own class, so the alpha has to be substituted at the draw
+    // call they use.
+    //
+    // Known gap, pre-26.1 only: cape geometry keeps its opacity. CapePiece draws through
+    // `CapeModel`, an Immersive Armors class, and an @At target cannot be written for it in a
+    // remap-safe way — the owner is a mod class (so `remap = true` cannot resolve it) while the
+    // descriptor is all Minecraft types (so `remap = false` matches dev but not a released,
+    // intermediary-mapped jar). Silently emitting a target that only binds in dev is worse than the
+    // gap, so it is left uncovered. Full-hide still works on capes there, because it is the whole
+    // `render` call that gets cancelled; only partial transparency is affected. From 26.1 onward
+    // capes fade normally.
+
+    //? if >= 1.21 && < 26.1-0.snapshot {
+    /*@WrapOperation(
+            method = "render",
+            require = 0,
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/client/model/geom/ModelPart;render(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V",
+                    remap = true)
+    )
+    private void armorHider$fadeSubPiecePartColor(ModelPart part, PoseStack poseStack, VertexConsumer vertexConsumer,
+            int packedLight, int packedOverlay, int color, Operation<Void> original) {
+        original.call(part, poseStack, vertexConsumer, packedLight, packedOverlay,
+                AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE)
+                        .renderModificationApi().applyArmorTransparency(color));
+    }
+    *///?}
+
+    //? if < 1.21 {
+    /*@WrapOperation(
+            method = "render",
+            require = 0,
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/client/model/geom/ModelPart;render(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;IIFFFF)V",
+                    remap = true)
+    )
+    private void armorHider$fadeSubPiecePartAlpha(ModelPart part, PoseStack poseStack, VertexConsumer vertexConsumer,
+            int packedLight, int packedOverlay, float red, float green, float blue, float alpha,
+            Operation<Void> original) {
+        var ctx = AhRenderManagementApi.getActiveScope(RenderScope.ARMOR_PIECE);
+        if (ctx.isEmpty()) {
+            original.call(part, poseStack, vertexConsumer, packedLight, packedOverlay, red, green, blue, alpha);
+            return;
+        }
+        original.call(part, poseStack, vertexConsumer, packedLight, packedOverlay, red, green, blue,
+                ctx.renderModificationApi().getTransparencyAlpha());
+    }
+    *///?}
+}
+//?}

--- a/common/src/main/java/de/zannagh/armorhider/api/compat/CompatFlags.java
+++ b/common/src/main/java/de/zannagh/armorhider/api/compat/CompatFlags.java
@@ -125,7 +125,15 @@ public enum CompatFlags {
      *
      * @since 0.12.5
      */
-    FIRST_PERSON_MODEL(1<<16, "dev.tr7zw.firstperson.FirstPersonModelCore");
+    FIRST_PERSON_MODEL(1<<16, "dev.tr7zw.firstperson.FirstPersonModelCore"),
+
+    /**
+     * Immersive Armors (Conczin), which cancels the vanilla equipment layer and draws its own armor
+     * items as a list of {@code Piece}s.
+     *
+     * @since 0.12.5
+     */
+    IMMERSIVE_ARMORS(1<<17, "immersive_armors.client.render.entity.piece.Piece");
 
     private final long compatFlagValue;
 

--- a/common/src/main/java/de/zannagh/armorhider/mixin/FabricClientMixinPlugin.java
+++ b/common/src/main/java/de/zannagh/armorhider/mixin/FabricClientMixinPlugin.java
@@ -54,6 +54,8 @@ public abstract class FabricClientMixinPlugin extends ArmorHiderMixinPlugin {
             "compat.deeperdarker.WardenHelmetLayerMixin",
             "compat.deeperdarker.HelmetHornLayerMixin",
             "compat.uranus.UranusArmorRendererMixin",
+            "compat.immersivearmors.ImmersiveArmorsPieceMixin",
+            "compat.immersivearmors.ImmersiveArmorsPieceGeometryMixin",
             "compat.emf.EmfModelPartMixin",
             "compat.emf.EmfModelPartRootMixin",
             "compat.curios.CuriosLayerMixin",

--- a/common/src/main/java/de/zannagh/armorhider/mixin/NeoForgeClientMixinPlugin.java
+++ b/common/src/main/java/de/zannagh/armorhider/mixin/NeoForgeClientMixinPlugin.java
@@ -59,6 +59,8 @@ public class NeoForgeClientMixinPlugin extends ArmorHiderMixinPlugin {
             "compat.deeperdarker.WardenHelmetLayerMixin",
             "compat.deeperdarker.HelmetHornLayerMixin",
             "compat.uranus.UranusArmorRendererMixin",
+            "compat.immersivearmors.ImmersiveArmorsPieceMixin",
+            "compat.immersivearmors.ImmersiveArmorsPieceGeometryMixin",
             // Compat - Pseudo and guarded in source for mekanism constant only (1.21.1 Neo)
             "compat.mekanism.MekanismArmorMixin",
             "compat.mekanism.MekaSuitArmorMixin",

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -133,6 +133,7 @@ deeperdarker.version = "GeXcCDSS" # 1.20.1 fabric
 modmenu.version = "lEkperf6"
 gender.version = "nYZ0oktX"
 fabricapi.version = "hu6gukgT"
+immersivearmors.version = "mGE2GYeN" # 1.7.2+1.20.1 fabric
 
 ["fabric-1.21.1"]
 "fabric.minecraft_version" = "1.21.1"
@@ -147,6 +148,7 @@ modmenu.version = "v6Xx3fbU"
 waveycapes.version = "EcKyPvJR"
 gender.version = "kJmjQvAS"
 fabricapi.version = "Lwt6YYHL"
+immersivearmors.version = "4m0lwLNO" # 1.7.6+1.21.1 fabric
 # fabric-api 0.116.x for 1.21.1 predates fabric-client-gametest-api-v1 — Phase 2 entity
 # render smoke can't be wired here. fabricapi.semver intentionally omitted; the variant
 # stays on Phase 1 boot smoke only.
@@ -308,6 +310,7 @@ firstperson.version = "PBg45FeB" # 2.7.2 (mc26.1 jar, covers 26.1/26.1.1/26.1.2)
 loader_version = "0.19.3"
 fabricapi.version = "WC1KT7Yg"
 fabricapi.semver = "0.153.0+26.1.2"
+immersivearmors.version = "De0vtARW" # 1.8.1+26.1.2 fabric
 
 ["fabric-26.2-snapshot-3"]
 "fabric.minecraft_version" = "26.2-alpha.3"
@@ -353,6 +356,7 @@ fabricapi.version = "M8Kbv865"
 # of individual API modules off fabric maven (e.g. fabric-client-gametest-api-v1 for the
 # Phase 2 entity-render smoke test). Mirrors `fabricapi.version`'s Modrinth hash.
 fabricapi.semver = "0.153.0+26.2"
+immersivearmors.version = "8gIhM6R2" # 1.8.1+26.2 fabric
 
 ["fabric-26.3-snapshot-5"]
 "fabric.minecraft_version" = "26.3-alpha.5"
@@ -393,6 +397,7 @@ gender.version = "kKffHCGl" # 3.2.2
 # Routes the gender compat through GenderLegacyLayerMixin (coarse hide-cancel only;
 # no transparency or trim recolor on this combo).
 gender_legacy_api = "true"
+immersivearmors.version = "B2YtQYCh" # 1.7.6+1.21.1 neoforge
 
 ["neoforge-1.21.2"]
 "neoforge.version" = "21.2.1-beta"
@@ -475,6 +480,7 @@ elytratrims.version = "wgUBgHvL"
 iris.version = "MwcLS51S"
 emf.version = "hABUrVHX"
 etf.version = "J8nN7dGg"
+immersivearmors.version = "1zKCa66X" # 1.8.1+26.1.2 neoforge
 
 ["neoforge-26.2"]
 "neoforge.version" = "26.2.0.32-beta"
@@ -484,3 +490,4 @@ elytratrims.version = "kHpKqNuJ"
 iris.version = "3uIIps8q"
 emf.version = "QxbPFvdn"
 etf.version = "NrV7O0NJ"
+immersivearmors.version = "hga2z8pc" # 1.8.1+26.2 neoforge


### PR DESCRIPTION
This adds compatibility to immersive armors. 26.x versions are currently limited by Luke100000/ImmersiveArmors#141 which causes all sorts of visual misbehavior when using partial transparency (not an issue caused by slot resolution on Armor Hider end, can cause overlapping armor pieces and the likes due to no slot resolution). Code itself is ready for the proposed fix, an update of IA will resolve the visual issues on transparency too.