### PR TITLE
fix: fgm chestplate armor translucency with armored elytra

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  determine-runner:
-    name: Determine Runner
+  runner-and-version:
+    name: Determine Runner & Get Version
     runs-on: ubuntu-latest
     outputs:
       runner: ${{ steps.pick.outputs.runner }}
+      fullSemVer: ${{ steps.version.outputs.fullSemVer }}
     steps:
       - name: Pick a runner
         id: pick
@@ -30,26 +31,28 @@ jobs:
           runner-token: ${{ secrets.RUNNER_TOKEN }}
           required-labels: 'Linux,X64,build'
           default-runs-on: 'ubuntu-latest'
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Calculate Version
+        id: version
+        uses: zannagh/versionizer/calculate-version@v1
 
   build:
     name: Build & Test
-    needs: determine-runner
-    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+    needs: runner-and-version
+    runs-on: ${{ fromJSON(needs.runner-and-version.outputs.runner) }}
     defaults:
       run:
         shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Setup Gradle Environment
         uses: zannagh/versionizer/setup-gradle-env@v1
-
-      - name: Calculate Version
-        id: version
-        uses: zannagh/versionizer/calculate-version@v1
 
       # `stageArtifacts` below compiles everything but runs NO tests, so without this step the job
       # only ever checked that the project builds. Runs first, to fail fast.
@@ -76,11 +79,11 @@ jobs:
           ./gradlew :paper:test ":common:${ACTIVE}:test"
 
       - name: Build & Stage Artifacts
-        run: ./gradlew stageArtifacts -PsemVer="${{ steps.version.outputs.fullSemVer }}" -Pprerelease="true"
+        run: ./gradlew stageArtifacts -PsemVer="${{ needs.runner-and-version.outputs.fullSemVer }}" -Pprerelease="true"
 
-      - name: Upload Build Artifacts
+      - name: Upload Staged Artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: armor-hider-${{ steps.version.outputs.fullSemVer }}
+          name: armor-hider-${{ needs.runner-and-version.outputs.fullSemVer }}
           path: staging/*.jar
           if-no-files-found: warn

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,19 +1,9 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches:
-      - "main"
-      - 'release/**'
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
-      - '**/*.png'
-      - '**/*.yml'
   pull_request:
     branches:
       - "main"
-      - 'release/**'
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
@@ -23,25 +13,9 @@ on:
     - cron: '16 20 * * 1'
 
 jobs:
-  determine-runner:
-    name: Determine Runner
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.pick.outputs.runner }}
-    steps:
-      - name: Pick a runner
-        id: pick
-        uses: zannagh/versionizer/determine-runner@v1
-        with:
-          # Fine-grained PAT with Administration:read on this repo (lists runners). Missing/invalid
-          # token degrades gracefully to default-runs-on.
-          runner-token: ${{ secrets.RUNNER_TOKEN }}
-          required-labels: 'Linux,X64,codeql'
-          default-runs-on: 'ubuntu-latest'
   analyze:
     name: Analyze (${{ matrix.language }})
-    needs: determine-runner
-    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
@@ -60,32 +34,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Setup Gradle Environment
-        uses: zannagh/versionizer/setup-gradle-env@v1
-        with:
-          java-distribution: 'microsoft'
-
-      - name: Cache NeoForge NFRT Artifacts
-        uses: actions/cache@v6
-        with:
-          path: neoforge/versions/*/build/moddev/artifacts/
-          key: nfrt-${{ runner.os }}-${{ hashFiles('neoforge/versions/*/gradle.properties') }}
-
+      # build-mode: none extracts straight from source - no compiler, no Gradle. The repo is Java
+      # only (the sole Kotlin is buildSrc Gradle logic, which `none` skips and which carries nothing
+      # worth scanning), so this analyses every one of the 288 Java sources with none of the cost of
+      # a traced build. If shipped Kotlin is ever added, switch this back to a traced build (drop
+      # build-mode, restore a Gradle compile step) so kotlinc gets traced.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-
-      # CodeQL only needs the sources compiled; running the suite here was incidental, and the unit
-      # tests are now the Build workflow's job (it gates pull requests).
-      #
-      # `testClasses` is explicit because `-x test` alone would also drop `compileTestJava` - it is
-      # only reachable through `test` - which would quietly shrink CodeQL's analysis scope to
-      # main sources. This keeps exactly what plain `build` compiled, minus the execution.
-      - name: Build
-        run: ./gradlew build testClasses -x test
+          build-mode: ${{ matrix.build-mode }}
+          # Default suite is security-only and deliberately narrow; security-and-quality adds the
+          # maintainability/quality query family so the code-scanning overview reflects both. Quality
+          # queries work fully on source, so they pair well with build-mode: none. (The deepest
+          # dataflow security queries would benefit from a traced build that resolves deps, but for a
+          # client-side mod the source-only extraction is an acceptable trade.)
+          queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"
+          upload: true

--- a/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/wildfiregender/GenderArmorLayerMixin.java
+++ b/common/src/client/java/de/zannagh/armorhider/client/mixin/compat/wildfiregender/GenderArmorLayerMixin.java
@@ -126,8 +126,19 @@ public class GenderArmorLayerMixin {
         // window and then popped straight to hidden the moment the combat event expired, while every
         // vanilla armor piece faded smoothly. shouldEnforceVanillaRendering() governs which *model* is
         // used (EquipmentRenderMixin, EMF), not opacity, and has no meaning for the mod's own breast model.
+        //
+        // Armored Elytra (dorkix): the worn chest item is a plain Items.ELYTRA (chestplate stashed in
+        // CUSTOM_DATA), so its ItemInfo.isArmoredElytra() is false and the ARMOR_PIECE renderer would
+        // delegate this breast piece to the ELYTRA renderer - making its opacity follow opacityAffectElytra
+        // instead of the chest slot. But the breast armor IS the stored chestplate's armor (FGM resolves it
+        // via WildfireHelperMixin), and the vanilla body plate dorkix swaps into HumanoidArmorLayer already
+        // follows the chest opacity. Feed the interception the underlying chestplate so the breast is scoped
+        // as ARMOR_PIECE/chest and stays in lockstep with the body plate - e.g. with opacityAffectElytra OFF
+        // the chestplate hides yet the wings stay visible, which is the whole point of an armored elytra.
+        // Non-armored-elytra stacks (and a real chestplate) pass through unchanged.
+        ItemStack effectiveStack = de.zannagh.armorhider.client.compat.ArmoredElytraCompat.underlyingChestplateOrSelf(stack);
         var interceptionResult = AhRenderInterceptionRegistryApi
-                .getRenderer(RenderScope.ARMOR_PIECE).intercept(state, slot, stack, ci);
+                .getRenderer(RenderScope.ARMOR_PIECE).intercept(state, slot, effectiveStack, ci);
         if (!interceptionResult.shouldIntercept()) {
             return Pair.of(false, interceptionResult);
         }

--- a/common/src/client/java/de/zannagh/armorhider/smoke/ArmoredElytraGenderSmokeTest.java
+++ b/common/src/client/java/de/zannagh/armorhider/smoke/ArmoredElytraGenderSmokeTest.java
@@ -121,8 +121,36 @@ public final class ArmoredElytraGenderSmokeTest implements FabricClientGameTest 
                         + " was drawn (swap delta " + withElytra + ") - the CUSTOM_DATA substitution fired without the"
                         + " mod present; it must be gated on CompatFlags.ARMORED_ELYTRA");
             }
+
+            // ── Armored elytra with opacityAffectElytra OFF: the breast is chest armor, not a wing, so it
+            //    must STILL fade in lockstep with the hidden chestplate (the swap keeps climbing). Turning
+            //    the elytra toggle off keeps the wings visible - the whole point of an armored elytra - but
+            //    must not spare the breast. Before interceptArmor substituted the underlying chestplate the
+            //    breast delegated to the ELYTRA renderer and, with this toggle off, rendered fully opaque
+            //    (swap delta 0) while the vanilla body plate hid: the reported bug. ────────────────────────
+            context.runOnClient(client -> {
+                var config = ArmorHiderClient.CLIENT_CONFIG_MANAGER
+                        .resolveConfig(ArmorHiderClient.getCurrentPlayerName());
+                config.opacityAffectingElytra.setValue(false);
+            });
+            context.waitTicks(10);
+            long elytraToggleOff = breastSwapDelta(context);
+            context.takeScreenshot("armorhider_ae_gender_3_elytratoggleoff");
+            ArmorHider.LOGGER.info("[smoke/fcgt] ARMORED-ELYTRA opacityAffectElytra=OFF: breast swap delta = {}",
+                    elytraToggleOff);
+            if (dorkixPresent && elytraToggleOff <= 0) {
+                throw new IllegalStateException("[smoke/fcgt] Armored-elytra breast did not fade with opacityAffectElytra"
+                        + " OFF (swap delta " + elytraToggleOff + ") - it is following the elytra toggle instead of the"
+                        + " chest slot; interceptArmor must substitute the underlying chestplate so the breast is scoped"
+                        + " ARMOR_PIECE like the body plate");
+            }
+            if (!dorkixPresent && elytraToggleOff > 0) {
+                throw new IllegalStateException("[smoke/fcgt] Armored Elytra mod ABSENT but the armored-elytra breast"
+                        + " faded with opacityAffectElytra OFF (swap delta " + elytraToggleOff + ") - the chestplate"
+                        + " substitution fired without the mod present; it must be gated on CompatFlags.ARMORED_ELYTRA");
+            }
             ArmorHider.LOGGER.info("[smoke/fcgt] Armored-elytra + gender smoke passed (control={}, armoredElytra={},"
-                    + " dorkixPresent={})", control, withElytra, dorkixPresent);
+                    + " elytraToggleOff={}, dorkixPresent={})", control, withElytra, elytraToggleOff, dorkixPresent);
         }
     }
 


### PR DESCRIPTION
This PR fixed the case of:
* armored elytra equipped
* opacity affect elytra setting turned off
* chest opacity set to 0%

As a user you'd expect the elytra to be drawn but none of the chestpieces to be rendered. Prior to this fix, the female gender mod chest piece would still be rendered in that case. It's not properly suppressed from rendering with this setting combination.